### PR TITLE
feat: declare action runtime as node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -89,5 +89,5 @@ outputs:
       EC2 Instance Id of the created runner.
       The id is used to terminate the EC2 instance when the runner is not needed anymore.
 runs:
-  using: node12
+  using: node24
   main: ./dist/index.js


### PR DESCRIPTION
## Summary

One-line change in `action.yml`: `using: node12` → `using: node24`.

## Why

The action still declared the oldest Node runtime GitHub ever supported. GitHub has been auto-shimming `node12` forward for years (through `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION`), and the current runner (v2.333.1, merged in #3) now surfaces this warning on every consumer's Actions page:

> Node.js 20 actions are deprecated. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

Declaring `node24` explicitly aligns the action with what the runner already bundles (`externals/node24`), silences the deprecation warning for every downstream consumer (screenshotted on `namecheap/terraform-provider-namecheap` [here](https://github.com/namecheap/terraform-provider-namecheap/actions/runs/)), and is the direction GitHub is forcing us anyway.

## Compatibility check on dist/index.js

Grep'd for Node-22+ removals across the bundle:

| API | Occurrences | Notes |
|---|---|---|
| `util.isArray`, `util.isBoolean`, `util.isDate`, etc. | 0 | removed in Node 23 |
| `createCipher` / `createDecipher` (without `iv`) | 0 | removed in Node 22 |
| `new Buffer(...)` | 2 | (1) inside a lodash docstring comment, not executed; (2) `tunnel-agent`'s proxy-auth path that we never invoke. Emits `DEP0005` but still works on node24 |

Nothing blocks node24 execution.

## Reproducibility

`NODE_OPTIONS=--openssl-legacy-provider npm run package` produces a byte-identical `dist/index.js`. The `verify-dist` CI job (added in #3) will confirm on this PR.

## Downstream follow-up

After this merges, `namecheap/terraform-provider-namecheap` needs a SHA-pin rotation (two `uses:` lines in `ci.yml`). Same pattern as #158 → provider #159.