### PR TITLE
fix: write outputs to GITHUB_OUTPUT file instead of ::set-output

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -55441,12 +55441,23 @@ module.exports = {
 /***/ 4351:
 /***/ ((__unused_webpack_module, __unused_webpack_exports, __webpack_require__) => {
 
+const fs = __webpack_require__(35747);
+const os = __webpack_require__(12087);
 const aws = __webpack_require__(61150);
 const gh = __webpack_require__(56989);
 const config = __webpack_require__(34570);
 const core = __webpack_require__(42186);
 
+// Write directly to the $GITHUB_OUTPUT file. The bundled @actions/core
+// v1.2.6 still emits the deprecated '::set-output name=X::Y' workflow
+// command; GitHub runners now surface that as a warning. Bypass the
+// legacy path — modern runners always set GITHUB_OUTPUT.
 function setOutput(label, ec2InstanceId) {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (outputFile) {
+    fs.appendFileSync(outputFile, `label=${label}${os.EOL}ec2-instance-id=${ec2InstanceId}${os.EOL}`);
+    return;
+  }
   core.setOutput('label', label);
   core.setOutput('ec2-instance-id', ec2InstanceId);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,20 @@
+const fs = require('fs');
+const os = require('os');
 const aws = require('./aws');
 const gh = require('./gh');
 const config = require('./config');
 const core = require('@actions/core');
 
+// Write directly to the $GITHUB_OUTPUT file. The bundled @actions/core
+// v1.2.6 still emits the deprecated '::set-output name=X::Y' workflow
+// command; GitHub runners now surface that as a warning. Bypass the
+// legacy path — modern runners always set GITHUB_OUTPUT.
 function setOutput(label, ec2InstanceId) {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (outputFile) {
+    fs.appendFileSync(outputFile, `label=${label}${os.EOL}ec2-instance-id=${ec2InstanceId}${os.EOL}`);
+    return;
+  }
   core.setOutput('label', label);
   core.setOutput('ec2-instance-id', ec2InstanceId);
 }


### PR DESCRIPTION
## Summary

Stop emitting the deprecated `::set-output name=X::Y` workflow command. Write the `label` and `ec2-instance-id` outputs directly to the `GITHUB_OUTPUT` environment file instead.

Eleven-line change in `src/index.js`, identical eleven-line diff in the rebuilt `dist/index.js`. No dependency updates.

## Why

GitHub is forcing the issue:

> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files.

The warning was surfacing on every consumer's Actions page ([example](https://github.com/namecheap/terraform-provider-namecheap/actions/runs/24670994484)).

## Why not bump `@actions/core`

Originally tried bumping `@actions/core` from `^1.2.6` to `1.10.1+` (the version that writes to `$GITHUB_OUTPUT` internally). The dep chain now pulls `undici`, which uses modern-JS private class fields (`#caches`). `@vercel/ncc 0.25.1` (the version pinned here since 2021) is webpack-4-era and refuses to parse them:

```
Module parse failed: Unexpected character '#' (13:2)
```

Fixing the parse error requires a major `@vercel/ncc` bump (to 0.38.x / webpack 5), which rewrites the whole bundle — far bigger blast radius than this deprecation warrants. This PR stays within the existing toolchain.

## What changed

```diff
+const fs = require('fs');
+const os = require('os');
 const aws = require('./aws');
 const gh = require('./gh');
 const config = require('./config');
 const core = require('@actions/core');

 function setOutput(label, ec2InstanceId) {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (outputFile) {
+    fs.appendFileSync(outputFile, `label=${label}${os.EOL}ec2-instance-id=${ec2InstanceId}${os.EOL}`);
+    return;
+  }
   core.setOutput('label', label);
   core.setOutput('ec2-instance-id', ec2InstanceId);
 }
```

The `core.setOutput` fallback is kept for defense in depth — a pre-2022 runner without `GITHUB_OUTPUT` still works, just with the deprecation warning intact. All modern runners (v2.297+) set `GITHUB_OUTPUT`, so production CI takes the quiet path.

## Safety

Output values come from:
- `config.generateUniqueLabel()` — a `uuid.v4()` string, no newlines
- `ec2InstanceId` — AWS `i-…` identifier, alphanumeric only

Plain `key=value\n` is safe for both. No heredoc encoding needed.

## Verification

- `verify-dist` (added in #3) will confirm the rebuilt bundle matches the committed dist.
- `verify-runner-url` stays green (no URL change).
- `lint` stays green (no new ESLint-flagged patterns).
- End-to-end verification lands once consumers rotate their SHA pin — `namecheap/terraform-provider-namecheap` will need a 2-line bump mirroring #159.

## Stacking note

This sits on top of #4 (`using: node12 → node24`). Expected merge order is #4 first, then this one; the two don't interact.