### PR TITLE
fix: silence DEP0169 url.parse deprecation from bundled aws-sdk v2

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -55441,6 +55441,21 @@ module.exports = {
 /***/ 4351:
 /***/ ((__unused_webpack_module, __unused_webpack_exports, __webpack_require__) => {
 
+// Silence DEP0169 (`url.parse()` deprecation) — the bundled aws-sdk v2
+// uses url.parse() internally for endpoint parsing. aws-sdk v2 is in
+// maintenance mode so the warning will not be fixed upstream; we use
+// trusted EC2 endpoint URLs and migrating to aws-sdk v3 would require
+// rewriting the entire action. Intercept at process.emitWarning so we
+// only filter this one code and preserve every other warning, including
+// any user-installed 'warning' listeners and Node's default formatter.
+const originalEmitWarning = process.emitWarning;
+process.emitWarning = function emitWarning(warning, ...rest) {
+  const opts = rest[0];
+  const code = (typeof opts === 'string') ? rest[1] : (opts && opts.code);
+  if (code === 'DEP0169') return;
+  return originalEmitWarning.call(process, warning, ...rest);
+};
+
 const fs = __webpack_require__(35747);
 const os = __webpack_require__(12087);
 const aws = __webpack_require__(61150);

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,18 @@
+// Silence DEP0169 (`url.parse()` deprecation) — the bundled aws-sdk v2
+// uses url.parse() internally for endpoint parsing. aws-sdk v2 is in
+// maintenance mode so the warning will not be fixed upstream; we use
+// trusted EC2 endpoint URLs and migrating to aws-sdk v3 would require
+// rewriting the entire action. Intercept at process.emitWarning so we
+// only filter this one code and preserve every other warning, including
+// any user-installed 'warning' listeners and Node's default formatter.
+const originalEmitWarning = process.emitWarning;
+process.emitWarning = function emitWarning(warning, ...rest) {
+  const opts = rest[0];
+  const code = (typeof opts === 'string') ? rest[1] : (opts && opts.code);
+  if (code === 'DEP0169') return;
+  return originalEmitWarning.call(process, warning, ...rest);
+};
+
 const fs = require('fs');
 const os = require('os');
 const aws = require('./aws');


### PR DESCRIPTION
## Summary

Filter only `DEP0169` (`url.parse()` deprecation) at `process.emitWarning`. 15-line change in `src/index.js`, equivalent 15-line diff in rebuilt `dist/index.js`. No dependency updates.

## What surfaces the warning

The bundled `aws-sdk` v2 (`^2.809.0` → resolves to 2.814.0) calls `url.parse()` in three places in its distributed bundle. Only `AWS.util.urlParse` runs at runtime — it's called on every EC2 API invocation to parse service endpoints. Node 24 emits the deprecation on each call:

```
(node:2120) [DEP0169] DeprecationWarning: `url.parse()` behavior is not
standardized and prone to errors that have security implications.
Use the WHATWG URL API instead. CVEs are not issued for `url.parse()`
vulnerabilities.
```

Screenshot trail: the warning appeared on the very run that verified #4 / #5 landed and silenced the earlier `::set-output` and `node20` deprecations. One warning dies, the next surfaces.

## Why not bump aws-sdk or migrate to v3

- Bumping v2 to latest (`2.1693.0`) was tested — same three `url.parse()` sites still present. SDK v2 is in maintenance mode (end-of-support Nov 2025 per AWS), so this warning will not be fixed upstream.
- aws-sdk v3 *does* use WHATWG URL, but v3 is a ground-up rewrite with per-service packages and a different API (`@aws-sdk/client-ec2` + `new EC2Client({...})` + `send(new RunInstancesCommand({...}))`). Migrating `src/aws.js` is a project unto itself, far beyond the scope of silencing a benign deprecation for fully-trusted EC2 endpoint URLs we construct ourselves.

## Why the `process.emitWarning` override

A `process.on('warning', ...)` listener would be additive — Node's default stderr formatter is not a removable listener but a built-in path triggered from `process.emit('warning', ...)` regardless. To actually suppress the emission, we have to intercept at the source.

The override:
- Extracts `code` from both supported call shapes: positional `(msg, type, code, ctor)` and options-object `(msg, { code, type })`.
- Returns early only on `'DEP0169'`.
- Delegates everything else to the original `process.emitWarning`, which means user listeners, Node's default formatter, `--trace-deprecation`, `--throw-deprecation`, and any other machinery all continue to work for every other warning code.

## Verification

Local smoke test (three call shapes):

```
node /tmp/warning-smoke.js
-> DEP0169 (filtered, silent)
-> DEP0123 options form (passed through with Node's default format)
-> Plain 2-arg Warning (passed through)
```

`verify-dist` CI job (added in #3) confirms the rebuild is reproducible: `NODE_OPTIONS=--openssl-legacy-provider npm run package` produces exactly the committed `dist/index.js`.

## Consumer follow-up

Per the pattern established in #4 and #5, `namecheap/terraform-provider-namecheap` will rotate its SHA pin to the new `feat/al2023-support` tip after this merges. Two-line diff in its `ci.yml`.