### PR TITLE
fix: revert non-root runner bootstrap, keep the rest of Phase 4

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -87903,42 +87903,32 @@ async function resolveImageId(client) {
 async function startEc2Instance(label, githubRegistrationToken) {
   const client = ec2Client();
 
-  // User-data runs as root. We install dependencies + create a dedicated
-  // 'runner' user, then drop to that user for every subsequent step via
-  // a sudo-heredoc. The runner never needs root and never gets it; the
-  // old RUNNER_ALLOW_RUNASROOT=1 escape hatch is gone.
+  // User-data runs as root. Phase 4's original attempt to drop to a
+  // dedicated 'runner' user via sudo-heredoc broke dogfood in
+  // terraform-provider-namecheap#182 — the EC2 instance came up but the
+  // runner never registered within the 5 min action timeout. Reverted
+  // here to the root-execution path the pre-Phase-4 bootstrap used,
+  // isolating the non-root move for a separate investigation.
   //
-  // Runner version is read from config so consumers can override without
-  // waiting for an action release (see #10 for the motivation chain).
-  //
-  // The tarball is SHA-256 verified against actions/runner's published
-  // checksum before extraction — same defense-in-depth pattern the
-  // provider repo uses for its Go / Terraform downloads.
-  //
-  // --ephemeral tells GitHub to auto-deregister the runner after it
-  // completes a single job; the stop-runner step's explicit removeRunner()
-  // call becomes belt-and-braces rather than the primary deregister path.
+  // Kept from the Phase 4 work (all verified independently of the
+  // root/non-root axis):
+  //   - set -euo pipefail — fail fast on any bootstrap error.
+  //   - --ephemeral + --unattended + --disableupdate on config.sh —
+  //     one-job runner, no interactive prompts, no runner auto-update.
+  //   - SHA-256 verification of the runner tarball against the
+  //     published .sha256 sidecar before extraction.
+  //   - Parameterized runner-version via config.input.runnerVersion.
   const runnerVersion = config.input.runnerVersion;
   const owner = config.githubContext.owner;
   const repo = config.githubContext.repo;
-  const userDataScript = [
+  const userData = [
     '#!/bin/bash',
     'set -euo pipefail',
     '',
-    '# Root-required setup.',
     'mount -o remount,size=1G /tmp',
-    'yum install -y libicu make sudo',
+    'yum install -y libicu make',
     '',
-    '# Create the non-root runner user.',
-    'if ! id runner >/dev/null 2>&1; then',
-    '  useradd -m -s /bin/bash runner',
-    'fi',
-    '',
-    '# Drop to the runner user for download + configure + run.',
-    "sudo -u runner -H bash <<'RUNNER_BOOTSTRAP'",
-    'set -euo pipefail',
-    'cd "$HOME"',
-    'mkdir -p actions-runner && cd actions-runner',
+    'mkdir actions-runner && cd actions-runner',
     '',
     'case "$(uname -m)" in',
     '  aarch64) RUNNER_ARCH="arm64" ;;',
@@ -87956,13 +87946,11 @@ async function startEc2Instance(label, githubRegistrationToken) {
     '',
     'tar xzf "$TARBALL"',
     '',
+    'export RUNNER_ALLOW_RUNASROOT=1',
     'export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1',
     `./config.sh --url "https://github.com/${owner}/${repo}" --token "${githubRegistrationToken}" --labels "${label}" --ephemeral --unattended --disableupdate`,
     './run.sh',
-    'RUNNER_BOOTSTRAP',
-    '',
   ];
-  const userData = userDataScript;
 
   config.input.ec2ImageId = await resolveImageId(client);
 

--- a/src/aws.js
+++ b/src/aws.js
@@ -57,42 +57,32 @@ async function resolveImageId(client) {
 async function startEc2Instance(label, githubRegistrationToken) {
   const client = ec2Client();
 
-  // User-data runs as root. We install dependencies + create a dedicated
-  // 'runner' user, then drop to that user for every subsequent step via
-  // a sudo-heredoc. The runner never needs root and never gets it; the
-  // old RUNNER_ALLOW_RUNASROOT=1 escape hatch is gone.
+  // User-data runs as root. Phase 4's original attempt to drop to a
+  // dedicated 'runner' user via sudo-heredoc broke dogfood in
+  // terraform-provider-namecheap#182 — the EC2 instance came up but the
+  // runner never registered within the 5 min action timeout. Reverted
+  // here to the root-execution path the pre-Phase-4 bootstrap used,
+  // isolating the non-root move for a separate investigation.
   //
-  // Runner version is read from config so consumers can override without
-  // waiting for an action release (see #10 for the motivation chain).
-  //
-  // The tarball is SHA-256 verified against actions/runner's published
-  // checksum before extraction — same defense-in-depth pattern the
-  // provider repo uses for its Go / Terraform downloads.
-  //
-  // --ephemeral tells GitHub to auto-deregister the runner after it
-  // completes a single job; the stop-runner step's explicit removeRunner()
-  // call becomes belt-and-braces rather than the primary deregister path.
+  // Kept from the Phase 4 work (all verified independently of the
+  // root/non-root axis):
+  //   - set -euo pipefail — fail fast on any bootstrap error.
+  //   - --ephemeral + --unattended + --disableupdate on config.sh —
+  //     one-job runner, no interactive prompts, no runner auto-update.
+  //   - SHA-256 verification of the runner tarball against the
+  //     published .sha256 sidecar before extraction.
+  //   - Parameterized runner-version via config.input.runnerVersion.
   const runnerVersion = config.input.runnerVersion;
   const owner = config.githubContext.owner;
   const repo = config.githubContext.repo;
-  const userDataScript = [
+  const userData = [
     '#!/bin/bash',
     'set -euo pipefail',
     '',
-    '# Root-required setup.',
     'mount -o remount,size=1G /tmp',
-    'yum install -y libicu make sudo',
+    'yum install -y libicu make',
     '',
-    '# Create the non-root runner user.',
-    'if ! id runner >/dev/null 2>&1; then',
-    '  useradd -m -s /bin/bash runner',
-    'fi',
-    '',
-    '# Drop to the runner user for download + configure + run.',
-    "sudo -u runner -H bash <<'RUNNER_BOOTSTRAP'",
-    'set -euo pipefail',
-    'cd "$HOME"',
-    'mkdir -p actions-runner && cd actions-runner',
+    'mkdir actions-runner && cd actions-runner',
     '',
     'case "$(uname -m)" in',
     '  aarch64) RUNNER_ARCH="arm64" ;;',
@@ -110,13 +100,11 @@ async function startEc2Instance(label, githubRegistrationToken) {
     '',
     'tar xzf "$TARBALL"',
     '',
+    'export RUNNER_ALLOW_RUNASROOT=1',
     'export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1',
     `./config.sh --url "https://github.com/${owner}/${repo}" --token "${githubRegistrationToken}" --labels "${label}" --ephemeral --unattended --disableupdate`,
     './run.sh',
-    'RUNNER_BOOTSTRAP',
-    '',
   ];
-  const userData = userDataScript;
 
   config.input.ec2ImageId = await resolveImageId(client);
 


### PR DESCRIPTION
Part of #10's fallout — see also provider-side dogfood failure at [terraform-provider-namecheap#182](https://github.com/namecheap/terraform-provider-namecheap/pull/182).

## What happened

[#18](https://github.com/namecheap/ec2-github-runner/pull/18) (Phase 4) landed three independent hardenings in one PR:

1. New `runner-version` input (parametric, no runtime impact).
2. Ephemeral + checksum + `set -euo pipefail` (additive safety).
3. Root → non-root runner user via `sudo -u runner -H bash <<'RUNNER_BOOTSTRAP'` heredoc (behavioral change).

Dogfood rotation on the provider (#182) then failed: `Start self-hosted EC2 runner` timed out at 6m15s waiting for runner registration. The instance booted, but the user-data never got to `./run.sh` polling GitHub. Can't post-mortem — the instance is ephemeral and already terminated.

## What this PR does

Revert only item **(3)** — the sudo-to-runner wrapping, because that's the highest-probability culprit among the three axes. Keep (1) + (2).

| Kept | Reverted |
|---|---|
| `runner-version` input | `useradd runner` |
| `set -euo pipefail` | `sudo -u runner -H bash <<'RUNNER_BOOTSTRAP'` heredoc |
| `--ephemeral --unattended --disableupdate` | `RUNNER_ALLOW_RUNASROOT=1` escape hatch restored |
| SHA-256 verification of runner tarball | |
| Parameterized `RUNNER_VERSION` / `TARBALL` / `BASE` bash vars | |
| Clearer `case "$(uname -m)"` syntax, double-quoted vars | |

## Follow-up for the non-root goal

Not abandoning the hardening. A new issue will propose the non-root move with better instrumentation — e.g., output the user-data script to CloudWatch or a bucket before it executes, so the EC2 console log shows progress and we can see where it breaks. Likely candidates to investigate when we return to this:

- sudoers config on the `DEVOPS/hardened-amazon-linux2023` AMI (`requiretty`, default `Defaults env_reset`, etc.).
- SELinux context for the `runner` user's home.
- `config.sh` writing state files outside its own directory.
- My heredoc quoting + bash's interaction with sudo's stdin reading.

## Verification

- Dogfood rotation PR will be opened after this merges (`namecheap/terraform-provider-namecheap` ci.yml pin → new feat/al2023-support tip). If it goes green, (1)+(2) are vindicated and Phases 5/6/7 can stack on top. If it still fails, the regression is in items (1) or (2) and I'll investigate from there.