### PR TITLE
revert: full rollback of Phase 4 bootstrap to Phase 1 known-good

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -68,20 +68,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Extract default runner version from action.yml
+      - name: Extract runner version from src/aws.js
         id: extract
         run: |
-          # action.yml declares:
-          #   runner-version:
-          #     ...
-          #     default: '2.333.1'
-          version=$(awk '/^  runner-version:/{found=1} found && /^    default:/{gsub(/[^0-9.]/, "", $2); print $2; exit}' action.yml)
+          version=$(grep -oE 'actions/runner/releases/download/v[0-9]+\.[0-9]+\.[0-9]+' src/aws.js | head -1 | sed 's|.*/v||')
           if [ -z "$version" ]; then
-            echo "::error::Could not locate the default runner-version in action.yml"
+            echo "::error::Could not locate the pinned actions/runner version in src/aws.js"
             exit 1
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "Default actions/runner: v$version"
+          echo "Pinned actions/runner: v$version"
       - name: HEAD check the Linux x64 release asset
         env:
           VERSION: ${{ steps.extract.outputs.version }}

--- a/action.yml
+++ b/action.yml
@@ -70,15 +70,6 @@ inputs:
       IAM Role Name to attach to the created EC2 instance.
       This requires additional permissions on the AWS role used to launch instances.
     required: false
-  runner-version:
-    description: >-
-      Version of the actions/runner binary to download and register.
-      Must match a released tag from https://github.com/actions/runner/releases
-      (without the 'v' prefix). Defaults to the version tested with this action release.
-      Bumping this lets consumers pick up a newer runner (e.g. when GitHub gates
-      JS actions on a newer node runtime) without waiting for an action release.
-    required: false
-    default: '2.333.1'
   aws-resource-tags:
     description: >-
       Tags to attach to the launched EC2 instance and volume.

--- a/dist/index.js
+++ b/dist/index.js
@@ -87903,52 +87903,19 @@ async function resolveImageId(client) {
 async function startEc2Instance(label, githubRegistrationToken) {
   const client = ec2Client();
 
-  // User-data runs as root. Phase 4's original attempt to drop to a
-  // dedicated 'runner' user via sudo-heredoc broke dogfood in
-  // terraform-provider-namecheap#182 — the EC2 instance came up but the
-  // runner never registered within the 5 min action timeout. Reverted
-  // here to the root-execution path the pre-Phase-4 bootstrap used,
-  // isolating the non-root move for a separate investigation.
-  //
-  // Kept from the Phase 4 work (all verified independently of the
-  // root/non-root axis):
-  //   - set -euo pipefail — fail fast on any bootstrap error.
-  //   - --ephemeral + --unattended + --disableupdate on config.sh —
-  //     one-job runner, no interactive prompts, no runner auto-update.
-  //   - SHA-256 verification of the runner tarball against the
-  //     published .sha256 sidecar before extraction.
-  //   - Parameterized runner-version via config.input.runnerVersion.
-  const runnerVersion = config.input.runnerVersion;
-  const owner = config.githubContext.owner;
-  const repo = config.githubContext.repo;
+  // User data scripts are run as the root user.
+  // Docker and git are necessary for GitHub runner and should be pre-installed on the AMI.
   const userData = [
     '#!/bin/bash',
-    'set -euo pipefail',
-    '',
     'mount -o remount,size=1G /tmp',
     'yum install -y libicu make',
-    '',
     'mkdir actions-runner && cd actions-runner',
-    '',
-    'case "$(uname -m)" in',
-    '  aarch64) RUNNER_ARCH="arm64" ;;',
-    '  amd64|x86_64) RUNNER_ARCH="x64" ;;',
-    '  *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;',
-    'esac',
-    '',
-    `RUNNER_VERSION="${runnerVersion}"`,
-    'TARBALL="actions-runner-linux-${RUNNER_ARCH}-${RUNNER_VERSION}.tar.gz"',
-    'BASE="https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}"',
-    '',
-    'curl -fsSLo "$TARBALL" "$BASE/$TARBALL"',
-    'expected="$(curl -fsSL "$BASE/$TARBALL.sha256" | awk \'{print $1}\')"',
-    'echo "$expected  $TARBALL" | sha256sum -c -',
-    '',
-    'tar xzf "$TARBALL"',
-    '',
+    'case $(uname -m) in aarch64) ARCH="arm64" ;; amd64|x86_64) ARCH="x64" ;; esac && export RUNNER_ARCH=${ARCH}',
+    'curl -O -L https://github.com/actions/runner/releases/download/v2.333.1/actions-runner-linux-${RUNNER_ARCH}-2.333.1.tar.gz',
+    'tar xzf ./actions-runner-linux-${RUNNER_ARCH}-2.333.1.tar.gz',
     'export RUNNER_ALLOW_RUNASROOT=1',
     'export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1',
-    `./config.sh --url "https://github.com/${owner}/${repo}" --token "${githubRegistrationToken}" --labels "${label}" --ephemeral --unattended --disableupdate`,
+    `./config.sh --url https://github.com/${config.githubContext.owner}/${config.githubContext.repo} --token ${githubRegistrationToken} --labels ${label}`,
     './run.sh',
   ];
 
@@ -88036,7 +88003,6 @@ class Config {
       label: core.getInput('label'),
       ec2InstanceId: core.getInput('ec2-instance-id'),
       iamRoleName: core.getInput('iam-role-name'),
-      runnerVersion: core.getInput('runner-version') || '2.333.1',
     };
 
     const tags = JSON.parse(core.getInput('aws-resource-tags'));

--- a/src/aws.js
+++ b/src/aws.js
@@ -57,52 +57,19 @@ async function resolveImageId(client) {
 async function startEc2Instance(label, githubRegistrationToken) {
   const client = ec2Client();
 
-  // User-data runs as root. Phase 4's original attempt to drop to a
-  // dedicated 'runner' user via sudo-heredoc broke dogfood in
-  // terraform-provider-namecheap#182 — the EC2 instance came up but the
-  // runner never registered within the 5 min action timeout. Reverted
-  // here to the root-execution path the pre-Phase-4 bootstrap used,
-  // isolating the non-root move for a separate investigation.
-  //
-  // Kept from the Phase 4 work (all verified independently of the
-  // root/non-root axis):
-  //   - set -euo pipefail — fail fast on any bootstrap error.
-  //   - --ephemeral + --unattended + --disableupdate on config.sh —
-  //     one-job runner, no interactive prompts, no runner auto-update.
-  //   - SHA-256 verification of the runner tarball against the
-  //     published .sha256 sidecar before extraction.
-  //   - Parameterized runner-version via config.input.runnerVersion.
-  const runnerVersion = config.input.runnerVersion;
-  const owner = config.githubContext.owner;
-  const repo = config.githubContext.repo;
+  // User data scripts are run as the root user.
+  // Docker and git are necessary for GitHub runner and should be pre-installed on the AMI.
   const userData = [
     '#!/bin/bash',
-    'set -euo pipefail',
-    '',
     'mount -o remount,size=1G /tmp',
     'yum install -y libicu make',
-    '',
     'mkdir actions-runner && cd actions-runner',
-    '',
-    'case "$(uname -m)" in',
-    '  aarch64) RUNNER_ARCH="arm64" ;;',
-    '  amd64|x86_64) RUNNER_ARCH="x64" ;;',
-    '  *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;',
-    'esac',
-    '',
-    `RUNNER_VERSION="${runnerVersion}"`,
-    'TARBALL="actions-runner-linux-${RUNNER_ARCH}-${RUNNER_VERSION}.tar.gz"',
-    'BASE="https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}"',
-    '',
-    'curl -fsSLo "$TARBALL" "$BASE/$TARBALL"',
-    'expected="$(curl -fsSL "$BASE/$TARBALL.sha256" | awk \'{print $1}\')"',
-    'echo "$expected  $TARBALL" | sha256sum -c -',
-    '',
-    'tar xzf "$TARBALL"',
-    '',
+    'case $(uname -m) in aarch64) ARCH="arm64" ;; amd64|x86_64) ARCH="x64" ;; esac && export RUNNER_ARCH=${ARCH}',
+    'curl -O -L https://github.com/actions/runner/releases/download/v2.333.1/actions-runner-linux-${RUNNER_ARCH}-2.333.1.tar.gz',
+    'tar xzf ./actions-runner-linux-${RUNNER_ARCH}-2.333.1.tar.gz',
     'export RUNNER_ALLOW_RUNASROOT=1',
     'export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1',
-    `./config.sh --url "https://github.com/${owner}/${repo}" --token "${githubRegistrationToken}" --labels "${label}" --ephemeral --unattended --disableupdate`,
+    `./config.sh --url https://github.com/${config.githubContext.owner}/${config.githubContext.repo} --token ${githubRegistrationToken} --labels ${label}`,
     './run.sh',
   ];
 

--- a/src/config.js
+++ b/src/config.js
@@ -16,7 +16,6 @@ class Config {
       label: core.getInput('label'),
       ec2InstanceId: core.getInput('ec2-instance-id'),
       iamRoleName: core.getInput('iam-role-name'),
-      runnerVersion: core.getInput('runner-version') || '2.333.1',
     };
 
     const tags = JSON.parse(core.getInput('aws-resource-tags'));

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -131,18 +131,6 @@ describe('Config — mode validation', () => {
   });
 });
 
-describe('Config — runner-version input', () => {
-  test('defaults to 2.333.1 when input is unset', () => {
-    const config = loadConfig(startModeInputs);
-    expect(config.input.runnerVersion).toBe('2.333.1');
-  });
-
-  test('honors an explicit runner-version override', () => {
-    const config = loadConfig({ ...startModeInputs, 'runner-version': '2.340.0' });
-    expect(config.input.runnerVersion).toBe('2.340.0');
-  });
-});
-
 describe('Config — generateUniqueLabel', () => {
   test('returns a 5-character alphanumeric string', () => {
     const config = loadConfig(startModeInputs);


### PR DESCRIPTION
Closes follow-ups: Phase 4's bootstrap changes need a redo. Full rollback here so the provider's acceptance tests work again.

## Why full revert

Two dogfood attempts failed with the identical 6m15s registration timeout:

| Attempt | Changes on top of Phase 1 | Dogfood |
|---|---|---|
| #18 (Phase 4 original) | non-root + `--ephemeral` + `--disableupdate` + checksum + `set -euo pipefail` + runner-version input | namecheap/terraform-provider-namecheap#182 — **failed at `Start self-hosted EC2 runner`** |
| #19 (fix-forward, reverted only non-root) | same minus non-root | namecheap/terraform-provider-namecheap#183 — **also failed identically** |

Both failures' `Start self-hosted EC2 runner` step times out after 5 min of polling for a registered runner, meaning the user-data bootstrap never reached `./run.sh`. Since #19 removed the non-root transition and still fails, the breaker is NOT the non-root move — it's somewhere in the rest of Phase 4's changes (`--ephemeral`, `--disableupdate`, checksum verify, `set -euo pipefail`, or parameterized bash vars).

Rather than another narrow-search iteration, revert the whole block to Phase 1 bytes and restart Phase 4 with one change per PR + one dogfood per PR.

## What this PR does

Checkout `a1bd2f9`'s (Phase 1 tip) `src/aws.js` / `src/config.js` / `action.yml` / `tests/` into the current tree. Rebuild `dist/`. Everything else from Phase 1 stays intact:

- aws-sdk v3 migration
- ncc 0.38 build
- jest test harness (21 tests, down from 23 — dropped the two `runner-version` tests)
- `.gitattributes` line-ending normalization for `dist/`

## What's lost

All five Phase 4 changes need to re-land via new issues / PRs:

- `runner-version` input (additive, zero runtime risk — easy relaunch)
- `set -euo pipefail` in user-data (the most likely actual breaker IMO — could be turning a previously-silent non-fatal step into a hard stop)
- `--ephemeral` + `--unattended` + `--disableupdate` on config.sh (could be flag-combination incompatibility with the installed runner version)
- SHA-256 verification of the runner tarball (could fail if `.sha256` URL returns an unexpected body)
- Parameterized `RUNNER_VERSION` / `TARBALL` / `BASE` bash vars (lowest risk)

Follow-up issue #20 (non-root move) is unchanged — still waiting on debug instrumentation.

## Next steps post-merge

1. Dogfood this tip on the provider. Expected: pass (it's Phase 1 behavior exactly).
2. Open five (or fewer if some combine naturally) small PRs, one per reintroduction of a Phase 4 change, each with its own dogfood.
3. First failure isolates the breaker and points the investigation.