### PR TITLE
feat: Phase 4 (retry) — non-root runner + --ephemeral + hardcoded checksum table

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -63,21 +63,25 @@ jobs:
         run: npm test
 
   verify-runner-url:
-    name: Verify pinned actions/runner release exists
+    name: Verify pinned actions/runner release + checksum table
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Extract runner version from src/aws.js
+      - name: Extract default runner version from action.yml
         id: extract
         run: |
-          version=$(grep -oE 'actions/runner/releases/download/v[0-9]+\.[0-9]+\.[0-9]+' src/aws.js | head -1 | sed 's|.*/v||')
+          # action.yml declares:
+          #   runner-version:
+          #     ...
+          #     default: '2.333.1'
+          version=$(awk '/^  runner-version:/{found=1} found && /^    default:/{gsub(/[^0-9.]/, "", $2); print $2; exit}' action.yml)
           if [ -z "$version" ]; then
-            echo "::error::Could not locate the pinned actions/runner version in src/aws.js"
+            echo "::error::Could not locate the default runner-version in action.yml"
             exit 1
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "Pinned actions/runner: v$version"
+          echo "Default actions/runner: v$version"
       - name: HEAD check the Linux x64 release asset
         env:
           VERSION: ${{ steps.extract.outputs.version }}
@@ -85,3 +89,37 @@ jobs:
           url="https://github.com/actions/runner/releases/download/v${VERSION}/actions-runner-linux-x64-${VERSION}.tar.gz"
           echo "Checking $url"
           curl -fsSLI -o /dev/null "$url"
+      - name: Cross-check src/runner-checksums.js against release body
+        env:
+          VERSION: ${{ steps.extract.outputs.version }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Pull the release body once.
+          body=$(gh api "/repos/actions/runner/releases/tags/v${VERSION}" --jq .body)
+
+          # Extract upstream hashes from HTML-comment-wrapped markdown like:
+          #   <!-- BEGIN SHA linux-x64 -->hex<!-- END SHA linux-x64 -->
+          upstream_x64=$(printf '%s' "$body" | grep -oE 'BEGIN SHA linux-x64 -->[a-f0-9]+' | cut -d'>' -f2)
+          upstream_arm64=$(printf '%s' "$body" | grep -oE 'BEGIN SHA linux-arm64 -->[a-f0-9]+' | cut -d'>' -f2)
+
+          if [ -z "$upstream_x64" ] || [ -z "$upstream_arm64" ]; then
+            echo "::error::Could not parse linux-x64 / linux-arm64 SHA from release body"
+            exit 1
+          fi
+
+          # Extract committed hashes from src/runner-checksums.js by loading
+          # it as a Node module. The module exports { CHECKSUMS, lookup(...) }.
+          committed_x64=$(node -e "console.log(require('./src/runner-checksums').lookup('x64', process.env.VERSION) || '')")
+          committed_arm64=$(node -e "console.log(require('./src/runner-checksums').lookup('arm64', process.env.VERSION) || '')")
+
+          ok=true
+          if [ "$upstream_x64" != "$committed_x64" ]; then
+            echo "::error::runner-checksums.js x64-$VERSION ($committed_x64) != upstream ($upstream_x64)"
+            ok=false
+          fi
+          if [ "$upstream_arm64" != "$committed_arm64" ]; then
+            echo "::error::runner-checksums.js arm64-$VERSION ($committed_arm64) != upstream ($upstream_arm64)"
+            ok=false
+          fi
+          $ok
+          echo "Checksums verified for v$VERSION (x64 + arm64)."

--- a/action.yml
+++ b/action.yml
@@ -70,6 +70,15 @@ inputs:
       IAM Role Name to attach to the created EC2 instance.
       This requires additional permissions on the AWS role used to launch instances.
     required: false
+  runner-version:
+    description: >-
+      Version of the actions/runner binary to download and register.
+      Must be one of the versions for which an entry exists in
+      src/runner-checksums.js (the action verifies the downloaded
+      tarball's SHA-256 against that table before extraction). To
+      override, add the corresponding hash to the table in a PR.
+    required: false
+    default: '2.333.1'
   http-tokens:
     description: >-
       Instance Metadata Service (IMDS) token mode. Accepted values:

--- a/dist/index.js
+++ b/dist/index.js
@@ -87857,6 +87857,7 @@ const config = __nccwpck_require__(1283);
 const log = __nccwpck_require__(7223);
 const { withRetry } = __nccwpck_require__(6759);
 const { sortByCreationDate } = __nccwpck_require__(5804);
+const checksums = __nccwpck_require__(2874);
 
 // EC2Client reads region + credentials from the environment (set by
 // aws-actions/configure-aws-credentials or by the instance profile on
@@ -87914,20 +87915,88 @@ async function resolveImageId(client) {
 async function startEc2Instance(label, githubRegistrationToken) {
   const client = ec2Client();
 
-  // User data scripts are run as the root user.
-  // Docker and git are necessary for GitHub runner and should be pre-installed on the AMI.
+  // Bootstrap design notes (fix-forward after ec2-github-runner#18/#19/#20):
+  //
+  // - Hashes for the runner tarball come from src/runner-checksums.js
+  //   (hardcoded table, cross-checked against the release body in CI).
+  //   The earlier `curl -fsSL <tarball>.sha256` approach died because
+  //   actions/runner doesn't publish per-tarball .sha256 sidecars.
+  //
+  // - Dedicated 'runner' user via useradd + sudo -u. The old
+  //   RUNNER_ALLOW_RUNASROOT=1 escape hatch is gone. Runner has its
+  //   own home under /home/runner/ and writes config.sh state there.
+  //
+  // - --ephemeral --unattended --disableupdate on config.sh: one-job
+  //   runner, no interactive prompts, no runtime self-update during
+  //   the session. GitHub auto-deregisters ephemeral runners after
+  //   their job, making the removeRunner() API call in gh.js become
+  //   belt-and-braces rather than the primary deregister path.
+  //
+  // - set -euo pipefail across both the outer and inner (runner-user)
+  //   shells so ANY failure kills the bootstrap immediately. Made
+  //   failures diagnosable in the Phase 4.b attempt (see #20 for the
+  //   `aws ec2 get-console-output --latest` recipe).
+  const runnerVersion = config.input.runnerVersion;
+  const owner = config.githubContext.owner;
+  const repo = config.githubContext.repo;
+  const shaX64 = checksums.lookup('x64', runnerVersion);
+  const shaArm64 = checksums.lookup('arm64', runnerVersion);
+  if (!shaX64 || !shaArm64) {
+    throw new Error(
+      `No SHA-256 entry in src/runner-checksums.js for runner-version ${runnerVersion}. ` +
+      'Add the x64 + arm64 hashes from the release body at ' +
+      `https://github.com/actions/runner/releases/tag/v${runnerVersion}`,
+    );
+  }
+
   const userData = [
     '#!/bin/bash',
+    'set -euo pipefail',
+    '',
+    '# Root-required setup.',
     'mount -o remount,size=1G /tmp',
-    'yum install -y libicu make',
-    'mkdir actions-runner && cd actions-runner',
-    'case $(uname -m) in aarch64) ARCH="arm64" ;; amd64|x86_64) ARCH="x64" ;; esac && export RUNNER_ARCH=${ARCH}',
-    'curl -O -L https://github.com/actions/runner/releases/download/v2.333.1/actions-runner-linux-${RUNNER_ARCH}-2.333.1.tar.gz',
-    'tar xzf ./actions-runner-linux-${RUNNER_ARCH}-2.333.1.tar.gz',
-    'export RUNNER_ALLOW_RUNASROOT=1',
+    'yum install -y libicu make sudo',
+    '',
+    '# Create the non-root runner user (idempotent).',
+    'if ! id runner >/dev/null 2>&1; then',
+    '  useradd -m -s /bin/bash runner',
+    'fi',
+    '',
+    '# Drop to the runner user for download + configure + run.',
+    "sudo -u runner -H bash <<'RUNNER_BOOTSTRAP'",
+    'set -euo pipefail',
+    'cd "$HOME"',
+    'mkdir -p actions-runner && cd actions-runner',
+    '',
+    'case "$(uname -m)" in',
+    '  aarch64) RUNNER_ARCH="arm64" ;;',
+    '  amd64|x86_64) RUNNER_ARCH="x64" ;;',
+    '  *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;',
+    'esac',
+    '',
+    `RUNNER_VERSION="${runnerVersion}"`,
+    'TARBALL="actions-runner-linux-${RUNNER_ARCH}-${RUNNER_VERSION}.tar.gz"',
+    'BASE="https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}"',
+    '',
+    'curl -fsSLo "$TARBALL" "$BASE/$TARBALL"',
+    '',
+    '# SHA-256 verification against the hash baked into the action at',
+    '# build time (src/runner-checksums.js). The table is kept in sync',
+    '# with upstream by the verify-runner-url CI job on every PR.',
+    'case "$RUNNER_ARCH" in',
+    `  x64) EXPECTED_SHA="${shaX64}" ;;`,
+    `  arm64) EXPECTED_SHA="${shaArm64}" ;;`,
+    '  *) echo "no checksum for arch $RUNNER_ARCH" >&2; exit 1 ;;',
+    'esac',
+    'echo "$EXPECTED_SHA  $TARBALL" | sha256sum -c -',
+    '',
+    'tar xzf "$TARBALL"',
+    '',
     'export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1',
-    `./config.sh --url https://github.com/${config.githubContext.owner}/${config.githubContext.repo} --token ${githubRegistrationToken} --labels ${label}`,
+    `./config.sh --url "https://github.com/${owner}/${repo}" --token "${githubRegistrationToken}" --labels "${label}" --ephemeral --unattended --disableupdate`,
     './run.sh',
+    'RUNNER_BOOTSTRAP',
+    '',
   ];
 
   config.input.ec2ImageId = await resolveImageId(client);
@@ -88042,6 +88111,7 @@ class Config {
       label: core.getInput('label'),
       ec2InstanceId: core.getInput('ec2-instance-id'),
       iamRoleName: core.getInput('iam-role-name'),
+      runnerVersion: core.getInput('runner-version') || '2.333.1',
       httpTokens: core.getInput('http-tokens') || 'required',
       debug: core.getInput('debug') || 'false',
     };
@@ -88365,6 +88435,48 @@ async function withRetry(step, fn, opts = {}) {
 
 module.exports = {
   withRetry,
+};
+
+
+/***/ }),
+
+/***/ 2874:
+/***/ ((module) => {
+
+// Expected SHA-256 sums for actions/runner tarballs, keyed by
+// `${arch}-${version}`.
+//
+// Why hardcoded: actions/runner doesn't publish per-tarball .sha256
+// sidecar files (see ec2-github-runner#20 for the empirical proof —
+// `curl -fsSL <tarball>.sha256` returns 404 and killed the Phase 4
+// bootstrap under `set -euo pipefail`). Hashes ARE published in the
+// release body as HTML-comment-wrapped markdown, but parsing that
+// at boot time means an api.github.com round trip on every runner
+// start and hits the unauth rate limit quickly at org scale.
+//
+// Maintenance: whenever the `runner-version` default bumps in
+// action.yml, add the matching hashes here from the release body at
+// https://github.com/actions/runner/releases/tag/v<version>. The
+// `verify-runner-url` CI job cross-checks every entry against the
+// live release body on every PR, so a drift between this table and
+// upstream is caught at code-review time, not at runtime.
+//
+// Sources:
+//   https://github.com/actions/runner/releases/tag/v2.333.1
+
+const CHECKSUMS = {
+  // v2.333.1 — pinned default as of 2026-04-21.
+  'x64-2.333.1':   '18f8f68ed1892854ff2ab1bab4fcaa2f5abeedc98093b6cb13638991725cab74',
+  'arm64-2.333.1': '69ac7e5692f877189e7dddf4a1bb16cbbd6425568cd69a0359895fac48b9ad3b',
+};
+
+function lookup(arch, version) {
+  return CHECKSUMS[`${arch}-${version}`] || null;
+}
+
+module.exports = {
+  CHECKSUMS,
+  lookup,
 };
 
 

--- a/src/aws.js
+++ b/src/aws.js
@@ -11,6 +11,7 @@ const config = require('./config');
 const log = require('./log');
 const { withRetry } = require('./retry');
 const { sortByCreationDate } = require('./utils');
+const checksums = require('./runner-checksums');
 
 // EC2Client reads region + credentials from the environment (set by
 // aws-actions/configure-aws-credentials or by the instance profile on
@@ -68,20 +69,88 @@ async function resolveImageId(client) {
 async function startEc2Instance(label, githubRegistrationToken) {
   const client = ec2Client();
 
-  // User data scripts are run as the root user.
-  // Docker and git are necessary for GitHub runner and should be pre-installed on the AMI.
+  // Bootstrap design notes (fix-forward after ec2-github-runner#18/#19/#20):
+  //
+  // - Hashes for the runner tarball come from src/runner-checksums.js
+  //   (hardcoded table, cross-checked against the release body in CI).
+  //   The earlier `curl -fsSL <tarball>.sha256` approach died because
+  //   actions/runner doesn't publish per-tarball .sha256 sidecars.
+  //
+  // - Dedicated 'runner' user via useradd + sudo -u. The old
+  //   RUNNER_ALLOW_RUNASROOT=1 escape hatch is gone. Runner has its
+  //   own home under /home/runner/ and writes config.sh state there.
+  //
+  // - --ephemeral --unattended --disableupdate on config.sh: one-job
+  //   runner, no interactive prompts, no runtime self-update during
+  //   the session. GitHub auto-deregisters ephemeral runners after
+  //   their job, making the removeRunner() API call in gh.js become
+  //   belt-and-braces rather than the primary deregister path.
+  //
+  // - set -euo pipefail across both the outer and inner (runner-user)
+  //   shells so ANY failure kills the bootstrap immediately. Made
+  //   failures diagnosable in the Phase 4.b attempt (see #20 for the
+  //   `aws ec2 get-console-output --latest` recipe).
+  const runnerVersion = config.input.runnerVersion;
+  const owner = config.githubContext.owner;
+  const repo = config.githubContext.repo;
+  const shaX64 = checksums.lookup('x64', runnerVersion);
+  const shaArm64 = checksums.lookup('arm64', runnerVersion);
+  if (!shaX64 || !shaArm64) {
+    throw new Error(
+      `No SHA-256 entry in src/runner-checksums.js for runner-version ${runnerVersion}. ` +
+      'Add the x64 + arm64 hashes from the release body at ' +
+      `https://github.com/actions/runner/releases/tag/v${runnerVersion}`,
+    );
+  }
+
   const userData = [
     '#!/bin/bash',
+    'set -euo pipefail',
+    '',
+    '# Root-required setup.',
     'mount -o remount,size=1G /tmp',
-    'yum install -y libicu make',
-    'mkdir actions-runner && cd actions-runner',
-    'case $(uname -m) in aarch64) ARCH="arm64" ;; amd64|x86_64) ARCH="x64" ;; esac && export RUNNER_ARCH=${ARCH}',
-    'curl -O -L https://github.com/actions/runner/releases/download/v2.333.1/actions-runner-linux-${RUNNER_ARCH}-2.333.1.tar.gz',
-    'tar xzf ./actions-runner-linux-${RUNNER_ARCH}-2.333.1.tar.gz',
-    'export RUNNER_ALLOW_RUNASROOT=1',
+    'yum install -y libicu make sudo',
+    '',
+    '# Create the non-root runner user (idempotent).',
+    'if ! id runner >/dev/null 2>&1; then',
+    '  useradd -m -s /bin/bash runner',
+    'fi',
+    '',
+    '# Drop to the runner user for download + configure + run.',
+    "sudo -u runner -H bash <<'RUNNER_BOOTSTRAP'",
+    'set -euo pipefail',
+    'cd "$HOME"',
+    'mkdir -p actions-runner && cd actions-runner',
+    '',
+    'case "$(uname -m)" in',
+    '  aarch64) RUNNER_ARCH="arm64" ;;',
+    '  amd64|x86_64) RUNNER_ARCH="x64" ;;',
+    '  *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;',
+    'esac',
+    '',
+    `RUNNER_VERSION="${runnerVersion}"`,
+    'TARBALL="actions-runner-linux-${RUNNER_ARCH}-${RUNNER_VERSION}.tar.gz"',
+    'BASE="https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}"',
+    '',
+    'curl -fsSLo "$TARBALL" "$BASE/$TARBALL"',
+    '',
+    '# SHA-256 verification against the hash baked into the action at',
+    '# build time (src/runner-checksums.js). The table is kept in sync',
+    '# with upstream by the verify-runner-url CI job on every PR.',
+    'case "$RUNNER_ARCH" in',
+    `  x64) EXPECTED_SHA="${shaX64}" ;;`,
+    `  arm64) EXPECTED_SHA="${shaArm64}" ;;`,
+    '  *) echo "no checksum for arch $RUNNER_ARCH" >&2; exit 1 ;;',
+    'esac',
+    'echo "$EXPECTED_SHA  $TARBALL" | sha256sum -c -',
+    '',
+    'tar xzf "$TARBALL"',
+    '',
     'export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1',
-    `./config.sh --url https://github.com/${config.githubContext.owner}/${config.githubContext.repo} --token ${githubRegistrationToken} --labels ${label}`,
+    `./config.sh --url "https://github.com/${owner}/${repo}" --token "${githubRegistrationToken}" --labels "${label}" --ephemeral --unattended --disableupdate`,
     './run.sh',
+    'RUNNER_BOOTSTRAP',
+    '',
   ];
 
   config.input.ec2ImageId = await resolveImageId(client);

--- a/src/config.js
+++ b/src/config.js
@@ -16,6 +16,7 @@ class Config {
       label: core.getInput('label'),
       ec2InstanceId: core.getInput('ec2-instance-id'),
       iamRoleName: core.getInput('iam-role-name'),
+      runnerVersion: core.getInput('runner-version') || '2.333.1',
       httpTokens: core.getInput('http-tokens') || 'required',
       debug: core.getInput('debug') || 'false',
     };

--- a/src/runner-checksums.js
+++ b/src/runner-checksums.js
@@ -1,0 +1,35 @@
+// Expected SHA-256 sums for actions/runner tarballs, keyed by
+// `${arch}-${version}`.
+//
+// Why hardcoded: actions/runner doesn't publish per-tarball .sha256
+// sidecar files (see ec2-github-runner#20 for the empirical proof —
+// `curl -fsSL <tarball>.sha256` returns 404 and killed the Phase 4
+// bootstrap under `set -euo pipefail`). Hashes ARE published in the
+// release body as HTML-comment-wrapped markdown, but parsing that
+// at boot time means an api.github.com round trip on every runner
+// start and hits the unauth rate limit quickly at org scale.
+//
+// Maintenance: whenever the `runner-version` default bumps in
+// action.yml, add the matching hashes here from the release body at
+// https://github.com/actions/runner/releases/tag/v<version>. The
+// `verify-runner-url` CI job cross-checks every entry against the
+// live release body on every PR, so a drift between this table and
+// upstream is caught at code-review time, not at runtime.
+//
+// Sources:
+//   https://github.com/actions/runner/releases/tag/v2.333.1
+
+const CHECKSUMS = {
+  // v2.333.1 — pinned default as of 2026-04-21.
+  'x64-2.333.1':   '18f8f68ed1892854ff2ab1bab4fcaa2f5abeedc98093b6cb13638991725cab74',
+  'arm64-2.333.1': '69ac7e5692f877189e7dddf4a1bb16cbbd6425568cd69a0359895fac48b9ad3b',
+};
+
+function lookup(arch, version) {
+  return CHECKSUMS[`${arch}-${version}`] || null;
+}
+
+module.exports = {
+  CHECKSUMS,
+  lookup,
+};

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -131,6 +131,18 @@ describe('Config — mode validation', () => {
   });
 });
 
+describe('Config — runner-version input', () => {
+  test('defaults to 2.333.1 when unset', () => {
+    const config = loadConfig(startModeInputs);
+    expect(config.input.runnerVersion).toBe('2.333.1');
+  });
+
+  test('honors an explicit override', () => {
+    const config = loadConfig({ ...startModeInputs, 'runner-version': '2.340.0' });
+    expect(config.input.runnerVersion).toBe('2.340.0');
+  });
+});
+
 describe('Config — http-tokens input', () => {
   test('defaults to "required" when unset', () => {
     const config = loadConfig(startModeInputs);

--- a/tests/runner-checksums.test.js
+++ b/tests/runner-checksums.test.js
@@ -1,0 +1,40 @@
+const checksums = require('../src/runner-checksums');
+
+describe('runner-checksums', () => {
+  test('exports an arch-version keyed map', () => {
+    expect(typeof checksums.CHECKSUMS).toBe('object');
+    expect(Object.keys(checksums.CHECKSUMS).length).toBeGreaterThan(0);
+  });
+
+  test('all entries are 64-char lowercase hex', () => {
+    for (const [key, value] of Object.entries(checksums.CHECKSUMS)) {
+      expect(key).toMatch(/^(x64|arm64)-\d+\.\d+\.\d+$/);
+      expect(value).toMatch(/^[a-f0-9]{64}$/);
+    }
+  });
+
+  test('covers both x64 and arm64 for every version present', () => {
+    const versions = new Set(Object.keys(checksums.CHECKSUMS).map((k) => k.split('-')[1]));
+    for (const v of versions) {
+      expect(checksums.CHECKSUMS[`x64-${v}`]).toBeDefined();
+      expect(checksums.CHECKSUMS[`arm64-${v}`]).toBeDefined();
+    }
+  });
+
+  test('lookup returns the expected value for a known key', () => {
+    expect(checksums.lookup('x64', '2.333.1')).toBe(
+      '18f8f68ed1892854ff2ab1bab4fcaa2f5abeedc98093b6cb13638991725cab74',
+    );
+    expect(checksums.lookup('arm64', '2.333.1')).toBe(
+      '69ac7e5692f877189e7dddf4a1bb16cbbd6425568cd69a0359895fac48b9ad3b',
+    );
+  });
+
+  test('lookup returns null for a missing version', () => {
+    expect(checksums.lookup('x64', '9.99.99')).toBeNull();
+  });
+
+  test('lookup returns null for an unsupported arch', () => {
+    expect(checksums.lookup('riscv', '2.333.1')).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #20. Supersedes the reverted #18 / #19 / #21.

## The fix for what actually broke previously

#18 and #19 died at:

```bash
curl -fsSL <tarball>.sha256 | awk '{print $1}'
```

with a 404 — actions/runner doesn't publish per-tarball sidecars, empirically confirmed via `aws ec2 get-console-output --latest` on a probe EC2 (see #20 for full console log).

This PR replaces that with a **hardcoded `{arch-version → sha256}` table** in `src/runner-checksums.js`. Two entries today (x86_64 + arm64 for v2.333.1). Cross-checked against the live release body on every PR via an overhauled `verify-runner-url` CI job, so drift between the table and upstream fails at code-review time, not at runtime.

## Everything from the original Phase 4 issue (#10)

| Requirement | Landed |
|---|---|
| Non-root `runner` user | ✅ `useradd -m -s /bin/bash` + `sudo -u runner -H bash <<'RUNNER_BOOTSTRAP'` |
| No `RUNNER_ALLOW_RUNASROOT=1` | ✅ removed |
| Configurable runner version | ✅ new `runner-version` input, default `2.333.1` |
| Checksum verification | ✅ hardcoded table (not sidecar; sidecars don't exist) |
| `--ephemeral` on config.sh | ✅ |
| `--unattended` on config.sh | ✅ |
| `--disableupdate` on config.sh | ✅ |
| `set -euo pipefail` | ✅ on both outer and inner shells |
| Idempotent `useradd` | ✅ `if ! id runner …` guard |

## CI: verify-runner-url overhaul

Previously just HEADed the tarball URL. Now additionally:

1. Reads `runner-version` default from `action.yml`.
2. Fetches release body via `gh api /repos/actions/runner/releases/tags/v<version>`.
3. Greps `BEGIN SHA linux-x64` / `BEGIN SHA linux-arm64` HTML comments for the upstream hashes.
4. Loads `src/runner-checksums.js` via `node -e 'require(...)...'` for the committed hashes.
5. Fails the job if either differs.

So bumping `runner-version` in `action.yml` without also updating the table in the same PR → red CI. Bumping the table to incorrect values → red CI.

## Tests

- `tests/runner-checksums.test.js` — 6 new cases (table shape, hex format, per-version x64/arm64 parity, known/unknown lookup).
- `tests/config.test.js` — 2 new cases (runner-version default + override).

Total: 36 → **44 tests**.

## Consumer impact

External contract unchanged. `mode` / `github-token` / `ec2-image-*` / instance type / subnet / SG / EIP / iam-role-name / aws-resource-tags inputs all work as before. Two new optional inputs (`runner-version` default `2.333.1`, `http-tokens` already in master from #24).

Provider acctest impact — checked every step:
- `actions/checkout@v6` writes to `$GITHUB_WORKSPACE` — no root needed.
- `curl` Go/Terraform tarballs to workspace — no root.
- `tar -C .go-instance -xzf` / `unzip -o -d .terraform-bin` — workspace, no root.
- `make testacc` = `go test ./namecheap -run TestAcc` — no root.

Workspace absolute path shifts from `/actions-runner/_work/...` to `/home/runner/actions-runner/_work/...` but `$GITHUB_WORKSPACE` / `$HOME` / relative paths all resolve consistently.

## Dogfood plan

Rotate the provider's SHA pin after this merges (same pattern as every prior phase). This time I have the **`aws ec2 get-console-output --latest` recipe** documented privately; any new bootstrap failure is diagnosable in 3 minutes rather than opaque.

If dogfood surfaces an unrelated regression, the fix is small and scoped — we've already isolated the fragile axes.