### PR TITLE
ci: upgrade actions/checkout from v2 to v4 in package.yml

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: main
       - name: Install packages


### PR DESCRIPTION
## Summary

- Upgrades `actions/checkout@v2` (Node 20) to `@v4` (Node 24) in `package.yml`
- Fixes the Node.js 20 deprecation warning from run [#25913630835](https://github.com/namecheap/ec2-github-runner/actions/runs/25913630835)
- Action pinned by SHA (`34e1148`) per supply-chain policy
- `pr.yml` already uses `actions/checkout@v4` — no change needed there

## Test plan

- [ ] Package workflow runs without Node.js 20 deprecation warning