### PR TITLE
ci: add build provenance attestation for dist/index.js

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -9,6 +9,10 @@ jobs:
   package:
     name: Package distribution files
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -20,6 +24,10 @@ jobs:
         run: npm run lint
       - name: Package
         run: npm run package
+      - name: Attest dist provenance
+        uses: actions/attest-build-provenance@96b4a1ef7235a096b17240c259729fdd70c83d45 # v2
+        with:
+          subject-path: dist/index.js
       - name: Commit
         run: |
           git config --global user.name "GitHub Actions"


### PR DESCRIPTION
## Summary

- Adds `actions/attest-build-provenance@v2` to the `package.yml` workflow
- Generates a signed SLSA provenance attestation for `dist/index.js` after each build
- Attestations are visible at https://github.com/namecheap/ec2-github-runner/attestations
- Required permissions added: `id-token: write`, `attestations: write`

## How it works

After `npm run package` builds the dist bundle, the attest step signs it using GitHub's OIDC token and publishes the attestation to the GitHub Sigstore-compatible store. Anyone can verify the artifact with:

```bash
gh attestation verify dist/index.js --repo namecheap/ec2-github-runner
```

## Test plan

- [ ] Package workflow completes successfully on merge to main
- [ ] Attestation appears at https://github.com/namecheap/ec2-github-runner/attestations