### PR TITLE
ci: upgrade attest-build-provenance to v4.1.0 (node24)

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Package
         run: npm run package
       - name: Attest dist provenance
-        uses: actions/attest-build-provenance@96b4a1ef7235a096b17240c259729fdd70c83d45 # v2
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: dist/index.js
       - name: Commit


### PR DESCRIPTION
## Summary

- Upgrades `actions/attest-build-provenance` from `v2` (Node 20) to `v4.1.0` (Node 24)
- Fixes Node.js 20 deprecation warning from run [#26498772611](https://github.com/namecheap/ec2-github-runner/actions/runs/26498772611)
- SHA pinned: `a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32`

## Test plan

- [ ] Package workflow runs without Node.js 20 deprecation warning