### PR TITLE
feat: orphan protection — TTL self-destruct + mode:cleanup reaper

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ This action reads AWS credentials from the environment. Two paths — pick one.
    }
    ```
 
-   If you use the `aws-resource-tags` parameter, you will also need to allow the permissions to create tags:
+   The action always tags every instance it launches — with its own signature tags (`ec2-github-runner:managed`, `:repository`, `:label`, `:started-at`, which the [cleanup reaper](#reaping-orphaned-runners-mode-cleanup) relies on) plus any `aws-resource-tags` you supply — so `ec2:CreateTags` at launch time is required:
 
    ```
    {
@@ -220,6 +220,8 @@ This action reads AWS credentials from the environment. Two paths — pick one.
     ]
    }
    ```
+
+   The base policy already grants `ec2:DescribeInstances` and `ec2:TerminateInstances`, which are all the `cleanup` reaper needs on the AWS side (it deregisters runners through the `github-token`). You can scope `TerminateInstances` to tagged instances with a `Condition` on `aws:ResourceTag/ec2-github-runner:managed` for defense in depth.
 
    These example policies above are provided as a guide. They can and most likely should be limited even more by specifying the resources you use.
 
@@ -317,6 +319,9 @@ Now you're ready to go!
 | `http-tokens` | Optional. Used only with the `start` mode. | Instance Metadata Service (IMDS) token mode (default `required`). <br><br> - `required` — IMDSv2 only; mitigates SSRF-style credential theft. <br> - `optional` — also allows IMDSv1; set only if a workload on the runner needs it. |
 | `encrypt-ebs` | Optional. Used only with the `start` mode. | When `true`, the root EBS volume is created with SSE-EBS encryption using the account's default AWS-managed key (default `false`). Volume size / type / IOPS are preserved from the AMI. |
 | `cleanup-on-start-failure` | Optional. Used only with the `start` mode. | When `true` (default), a runner that fails to bootstrap or register has its console output captured and is then terminated so the failed start doesn't leak a billing instance. Set `false` to leave the instance running for interactive debugging. <br><br> **Behavior change:** older versions left the instance running after a registration timeout; the default is now to terminate it. See [Troubleshooting a failed start](#troubleshooting-a-failed-start). |
+| `max-lifetime-minutes` | Optional. Used only with the `start` mode. | Hard upper bound (minutes) on the instance's lifetime (default `360`). The instance arms a self-shutdown timer and launches with `InstanceInitiatedShutdownBehavior=terminate`, so it terminates itself at the TTL even if GitHub, the workflow, and AWS APIs are all unreachable. Size it **above your longest legitimate job** — a job still running at the TTL is killed. Set `0` to disable. See [Reaping orphaned runners](#reaping-orphaned-runners-mode-cleanup). |
+| `max-age-minutes` | Optional. Used only with the `cleanup` mode. | A registered-but-idle runner instance older than this many minutes is reaped (default `120`). Instances whose runner is no longer registered are reaped regardless of age, subject to a 15-minute grace floor that protects in-flight starts. Busy runners are never reaped. |
+| `dry-run` | Optional. Used only with the `cleanup` mode. | When `true`, the reaper lists what it would terminate (and why) in the job summary without terminating anything or deregistering runners. Default `false`. |
 | `debug` | Optional. | When `true`, the action emits extra diagnostic output to the Actions log — inputs (secrets redacted), AWS SDK response metadata, and runner-registration poll details. Default `false`. |
 
 ### Environment variables
@@ -409,6 +414,32 @@ jobs:
 In [this discussion](https://github.com/machulav/ec2-github-runner/discussions/19), you can find feedback and examples from the users of the action.
 
 If you use this action in your workflow, feel free to add your story there as well 🙌
+
+## Reaping orphaned runners (`mode: cleanup`)
+
+The `stop` step runs with `if: always()`, but that still doesn't cover every leak path — a cancelled workflow where the stop job never scheduled, a runner crash, a GitHub/AWS outage mid-run, or the workflow being killed after `start` but before `stop`. Every leaked instance bills until someone notices. Two independent, defense-in-depth layers close these paths.
+
+### 1. TTL self-destruct (`max-lifetime-minutes`)
+
+Every launched instance arms a self-shutdown timer and runs with `InstanceInitiatedShutdownBehavior=terminate`, so it terminates itself at the TTL (default 6 hours) even if GitHub, the workflow, and the AWS control plane are all unreachable. This is an absolute upper bound, not a normal-path mechanism — normal termination still happens in the `stop` step.
+
+**Size `max-lifetime-minutes` above your longest legitimate job**, with headroom for bootstrap time; a job still running when the timer fires is killed. Set `0` to disable it (e.g. if you have very long jobs and rely solely on the reaper below).
+
+### 2. The reaper (`mode: cleanup`)
+
+Run the action in `cleanup` mode on a schedule. It finds instances **this action started in the current repository** (matched on its full signature tag set), cross-checks each against the GitHub runners API, and terminates the orphans:
+
+| Runner state for the instance | Action |
+| --- | --- |
+| Younger than the 15-min grace floor | **skip** (may be an in-flight start) |
+| No runner registered | **reap** |
+| Runner busy | **skip** (regardless of age) |
+| Runner idle, older than `max-age-minutes` | **reap** + deregister |
+| Runner idle, within `max-age-minutes` | **skip** |
+
+It writes a job-summary table of everything examined, reaped, and skipped (with reasons). Use `dry-run: true` to preview without terminating anything. A ready-to-use scheduled workflow is in [`docs/cleanup-workflow.yml`](docs/cleanup-workflow.yml).
+
+The reaper needs `ec2:DescribeInstances` + `ec2:TerminateInstances` (already in the base [permissions policy](#2-prepare-the-aws-access-credentials)) and deregisters runners through the `github-token`. It is scoped **per repository** — run it in each repo that uses the action.
 
 ## Troubleshooting a failed start
 

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,9 @@ inputs:
     description: >-
       Specify here which mode you want to use:
         - 'start' - to start a new runner;
-        - 'stop' - to stop the previously created runner.
+        - 'stop' - to stop the previously created runner;
+        - 'cleanup' - to reap leaked/orphaned runner instances this
+          action started in the current repository (run on a schedule).
     required: true
   github-token:
     description: >-
@@ -116,6 +118,32 @@ inputs:
       the instance running after a registration timeout.
     required: false
     default: 'true'
+  max-lifetime-minutes:
+    description: >-
+      Used only with the 'start' mode. Hard upper bound, in minutes, on
+      the runner instance's lifetime. The instance arms a self-shutdown
+      timer and launches with InstanceInitiatedShutdownBehavior=terminate,
+      so it terminates itself when the timer fires even if GitHub, the
+      workflow, and the AWS control plane are all unreachable. Size it
+      above your longest legitimate job. Set '0' to disable the timer.
+    required: false
+    default: '360'
+  max-age-minutes:
+    description: >-
+      Used only with the 'cleanup' mode. A registered-but-idle runner
+      instance older than this many minutes is considered orphaned and
+      reaped. Instances whose runner is no longer registered are reaped
+      regardless of age (subject to a 15-minute grace floor that protects
+      in-flight starts). Busy runners are never reaped.
+    required: false
+    default: '120'
+  dry-run:
+    description: >-
+      Used only with the 'cleanup' mode. When 'true', the reaper lists the
+      instances it would terminate (and why) in the job summary without
+      terminating anything or deregistering any runners.
+    required: false
+    default: 'false'
   debug:
     description: >-
       When 'true', the action emits extra diagnostic output to the

--- a/dist/index.js
+++ b/dist/index.js
@@ -104651,6 +104651,7 @@ module.exports = {
 const {
   EC2Client,
   DescribeImagesCommand,
+  DescribeInstancesCommand,
   DescribeTagsCommand,
   GetConsoleOutputCommand,
   RunInstancesCommand,
@@ -104669,6 +104670,16 @@ const checksums = __nccwpck_require__(2874);
 // The start action polls it to fail fast on cloud-init errors instead of
 // waiting out the full registration timeout. See buildUserData().
 const BOOTSTRAP_TAG_KEY = 'ec2-github-runner:bootstrap';
+
+// Signature tags stamped on every instance the action launches. The
+// cleanup reaper (mode: cleanup) uses managed + repository to find only
+// instances this action started in the current repo, and started-at /
+// label to make safe reap decisions. See buildTagSpecifications() and
+// listManagedInstances().
+const MANAGED_TAG_KEY = 'ec2-github-runner:managed';
+const REPO_TAG_KEY = 'ec2-github-runner:repository';
+const LABEL_TAG_KEY = 'ec2-github-runner:label';
+const STARTED_AT_TAG_KEY = 'ec2-github-runner:started-at';
 
 // Console-output capture caps: keep the printed tail useful but bounded so a
 // runaway boot log can't flood the Actions run output.
@@ -104790,7 +104801,23 @@ function buildEncryptedRootMapping(image) {
 //   registration timeout. Tagging is best-effort: it needs
 //   `ec2:CreateTags` on the instance profile and degrades to
 //   timeout-only detection when absent (every write is `|| true`).
-function buildUserData({ runnerVersion, owner, repo, label, githubRegistrationToken, shaX64, shaArm64 }) {
+function buildUserData({ runnerVersion, owner, repo, label, githubRegistrationToken, shaX64, shaArm64, maxLifetimeMinutes }) {
+  // TTL self-destruct (#42): arm a shutdown timer as an absolute upper
+  // bound on instance lifetime. Combined with
+  // InstanceInitiatedShutdownBehavior: terminate on RunInstances (set in
+  // startEc2Instance when enabled), the instance terminates itself even if
+  // GitHub, the workflow, and the AWS control plane all disappear. '0'
+  // disables it (no timer emitted). Best-effort: `|| true` so a missing
+  // shutdown binary never aborts the bootstrap.
+  const ttl = Number(maxLifetimeMinutes);
+  const ttlLines = Number.isFinite(ttl) && ttl > 0
+    ? [
+      '# TTL self-destruct: hard upper bound on instance lifetime (max-lifetime-minutes).',
+      `shutdown -h +${ttl} || true`,
+      '',
+    ]
+    : [];
+
   // Shared shell helpers, emitted verbatim into both the outer (root) and
   // inner (runner-user) shells — each shell re-derives instance identity
   // from IMDS so it can keep phoning home independently.
@@ -104817,6 +104844,7 @@ function buildUserData({ runnerVersion, owner, repo, label, githubRegistrationTo
     'GH_RUNNER_STEP=preparing',
     "trap 'gh_runner_phone_home \"failed:${GH_RUNNER_STEP}\"' ERR",
     '',
+    ...ttlLines,
     '# Root-required setup.',
     'GH_RUNNER_STEP=preparing',
     'gh_runner_phone_home preparing',
@@ -104881,6 +104909,31 @@ function buildUserData({ runnerVersion, owner, repo, label, githubRegistrationTo
   ].join('\n');
 }
 
+// Build the RunInstances TagSpecifications, stamping every launched
+// instance (and its volumes) with the action's signature tags on top of
+// any user-supplied aws-resource-tags. The signature lets the cleanup
+// reaper positively identify instances this action started in this repo.
+// User tags win on key collision (spread last) so callers can't be
+// silently overridden — except the reserved signature keys, which are
+// re-applied to keep the reaper's guarantees intact.
+function buildTagSpecifications(label, startedAtIso) {
+  const owner = config.githubContext.owner;
+  const repo = config.githubContext.repo;
+  const userTags = config.input.awsResourceTags || [];
+  const signatureKeys = new Set([MANAGED_TAG_KEY, REPO_TAG_KEY, LABEL_TAG_KEY, STARTED_AT_TAG_KEY]);
+  const tags = [
+    ...userTags.filter((t) => !signatureKeys.has(t.Key)),
+    { Key: MANAGED_TAG_KEY, Value: 'true' },
+    { Key: REPO_TAG_KEY, Value: `${owner}/${repo}` },
+    { Key: LABEL_TAG_KEY, Value: label },
+    { Key: STARTED_AT_TAG_KEY, Value: startedAtIso },
+  ];
+  return [
+    { ResourceType: 'instance', Tags: tags },
+    { ResourceType: 'volume', Tags: tags },
+  ];
+}
+
 async function startEc2Instance(label, githubRegistrationToken) {
   const client = ec2Client();
 
@@ -104897,7 +104950,8 @@ async function startEc2Instance(label, githubRegistrationToken) {
     );
   }
 
-  const userData = buildUserData({ runnerVersion, owner, repo, label, githubRegistrationToken, shaX64, shaArm64 });
+  const maxLifetimeMinutes = config.input.maxLifetimeMinutes;
+  const userData = buildUserData({ runnerVersion, owner, repo, label, githubRegistrationToken, shaX64, shaArm64, maxLifetimeMinutes });
 
   const resolved = await resolveImage(client);
   config.input.ec2ImageId = resolved.id;
@@ -104911,7 +104965,7 @@ async function startEc2Instance(label, githubRegistrationToken) {
     SubnetId: config.input.subnetId,
     SecurityGroupIds: [config.input.securityGroupId],
     IamInstanceProfile: { Name: config.input.iamRoleName },
-    TagSpecifications: config.tagSpecifications,
+    TagSpecifications: buildTagSpecifications(label, new Date().toISOString()),
     // IMDSv2 required by default. Mitigates SSRF-style IAM credential
     // theft from the runner — any metadata request must present a
     // session token. HttpPutResponseHopLimit: 1 prevents the token
@@ -104922,6 +104976,14 @@ async function startEc2Instance(label, githubRegistrationToken) {
       HttpEndpoint: 'enabled',
     },
   };
+
+  // TTL self-destruct: terminate (not stop) when the in-instance shutdown
+  // timer fires, so the hard lifetime bound actually frees the instance.
+  // Only set when the timer is armed (max-lifetime-minutes != 0) to keep
+  // the default launch behavior unchanged.
+  if (Number(maxLifetimeMinutes) > 0) {
+    params.InstanceInitiatedShutdownBehavior = 'terminate';
+  }
 
   if (config.input.encryptEbs === 'true') {
     const mappings = buildEncryptedRootMapping(resolved.image);
@@ -105098,6 +105160,48 @@ async function handleStartFailure(ec2InstanceId, opts = {}) {
   }
 }
 
+// List running/pending instances this action launched in the given repo,
+// for the cleanup reaper. Filtering is server-side on the full signature
+// (managed=true AND repository=repo) and re-validated client-side (belt-
+// and-braces: only instances carrying both signature tags are ever
+// returned, so a near-miss tag set can never be reaped). Each result
+// carries the parsed started-at (ms; falls back to LaunchTime) and label
+// the reaper needs to make its decision.
+async function listManagedInstances(repo) {
+  const client = ec2Client();
+  const resp = await client.send(new DescribeInstancesCommand({
+    Filters: [
+      { Name: `tag:${MANAGED_TAG_KEY}`, Values: ['true'] },
+      { Name: `tag:${REPO_TAG_KEY}`, Values: [repo] },
+      { Name: 'instance-state-name', Values: ['pending', 'running'] },
+    ],
+  }));
+
+  const instances = [];
+  for (const reservation of resp.Reservations || []) {
+    for (const instance of reservation.Instances || []) {
+      const tags = {};
+      for (const tag of instance.Tags || []) {
+        tags[tag.Key] = tag.Value;
+      }
+      // Client-side re-validation of the full signature.
+      if (tags[MANAGED_TAG_KEY] !== 'true' || tags[REPO_TAG_KEY] !== repo) {
+        continue;
+      }
+      const startedAtRaw = tags[STARTED_AT_TAG_KEY];
+      const startedAtMs = startedAtRaw && !Number.isNaN(Date.parse(startedAtRaw))
+        ? Date.parse(startedAtRaw)
+        : (instance.LaunchTime ? new Date(instance.LaunchTime).getTime() : null);
+      instances.push({
+        instanceId: instance.InstanceId,
+        label: tags[LABEL_TAG_KEY] || null,
+        startedAtMs,
+      });
+    }
+  }
+  return instances;
+}
+
 module.exports = {
   startEc2Instance,
   terminateEc2Instance,
@@ -105106,11 +105210,160 @@ module.exports = {
   getBootstrapStatus,
   getConsoleOutputTail,
   handleStartFailure,
+  listManagedInstances,
   // Exported for unit testing.
   buildEncryptedRootMapping,
   buildUserData,
+  buildTagSpecifications,
   redactSecrets,
   BOOTSTRAP_TAG_KEY,
+  MANAGED_TAG_KEY,
+  REPO_TAG_KEY,
+  LABEL_TAG_KEY,
+  STARTED_AT_TAG_KEY,
+};
+
+
+/***/ }),
+
+/***/ 5541:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+const log = __nccwpck_require__(7223);
+
+// Instances younger than this are never reaped, even if no runner is
+// registered for them yet — they may be in-flight starts still working
+// through the bootstrap/registration window. Keeps the reaper safe to run
+// concurrently with `mode: start`.
+const REAP_GRACE_MINUTES = 15;
+
+// Decide what to do with a single managed instance given its matching
+// GitHub runner (or null if none is registered). Pure function — no I/O —
+// so the full decision matrix is unit-testable.
+//
+//   within grace period         -> skip  (protect in-flight starts)
+//   no runner registered        -> reap  (leaked instance)
+//   runner busy                 -> skip  (job in progress, any age)
+//   runner idle, older than max -> reap + deregister
+//   runner idle, within max age  -> skip
+function decideReap(instance, runner, opts) {
+  const { nowMs, maxAgeMinutes, graceMinutes } = opts;
+  const ageMinutes = instance.startedAtMs != null ? (nowMs - instance.startedAtMs) / 60000 : Infinity;
+
+  if (ageMinutes < graceMinutes) {
+    return { action: 'skip', reason: 'within-grace-period', deregister: false };
+  }
+  if (!runner) {
+    return { action: 'reap', reason: 'runner-not-registered', deregister: false };
+  }
+  if (runner.busy) {
+    return { action: 'skip', reason: 'runner-busy', deregister: false };
+  }
+  if (ageMinutes > maxAgeMinutes) {
+    return { action: 'reap', reason: 'runner-idle-past-max-age', deregister: true };
+  }
+  return { action: 'skip', reason: 'runner-idle-within-max-age', deregister: false };
+}
+
+// Walk every managed instance in the repo, decide, and (unless dryRun)
+// terminate + deregister the ones that should be reaped. All AWS/GitHub
+// I/O and the clock are injected via deps so the orchestration is
+// testable end-to-end with mocks:
+//   deps.listManagedInstances(): Promise<Array<{instanceId,label,startedAtMs}>>
+//   deps.getRunnerByLabel(label): Promise<runner|null>
+//   deps.terminateInstance(id): Promise<void>
+//   deps.deregisterRunner(runnerId): Promise<void>
+//   deps.now(): number (ms)
+// A single instance failing to terminate/deregister is recorded on its row
+// and does not abort the sweep.
+async function runReaper(deps, opts = {}) {
+  const { listManagedInstances, getRunnerByLabel, terminateInstance, deregisterRunner, now } = deps;
+  const maxAgeMinutes = opts.maxAgeMinutes;
+  const graceMinutes = opts.graceMinutes ?? REAP_GRACE_MINUTES;
+  const dryRun = !!opts.dryRun;
+
+  const instances = await listManagedInstances();
+  const nowMs = now();
+  const rows = [];
+  let reaped = 0;
+  let skipped = 0;
+
+  for (const instance of instances) {
+    const runner = instance.label ? await getRunnerByLabel(instance.label) : null;
+    const decision = decideReap(instance, runner, { nowMs, maxAgeMinutes, graceMinutes });
+    const row = {
+      instanceId: instance.instanceId,
+      label: instance.label,
+      action: decision.action,
+      reason: decision.reason,
+      performed: false,
+    };
+
+    if (decision.action === 'reap') {
+      reaped += 1;
+      if (!dryRun) {
+        try {
+          await terminateInstance(instance.instanceId);
+          row.performed = true;
+          if (decision.deregister && runner) {
+            try {
+              await deregisterRunner(runner.id);
+              row.deregistered = true;
+            } catch (error) {
+              row.deregisterError = error.message;
+              log.error('reaper_deregister', { instance_id: instance.instanceId, runner_id: runner.id, error: error.name, message: error.message });
+            }
+          }
+        } catch (error) {
+          row.error = error.message;
+          log.error('reaper_terminate', { instance_id: instance.instanceId, error: error.name, message: error.message });
+        }
+      }
+    } else {
+      skipped += 1;
+    }
+
+    log.info('reaper_decision', { instance_id: instance.instanceId, label: instance.label, action: decision.action, reason: decision.reason, dry_run: dryRun });
+    rows.push(row);
+  }
+
+  return { examined: instances.length, reaped, skipped, dryRun, rows };
+}
+
+// Render the reaper result as a GitHub Actions job-summary markdown table.
+function renderCleanupSummary(summary) {
+  const heading = summary.dryRun ? 'EC2 runner cleanup (dry-run)' : 'EC2 runner cleanup';
+  const lines = [
+    `### ${heading}`,
+    '',
+    `Examined: **${summary.examined}** · Reaped: **${summary.reaped}** · Skipped: **${summary.skipped}**`,
+    '',
+    '| Instance | Label | Action | Reason | Result |',
+    '| --- | --- | --- | --- | --- |',
+  ];
+  for (const r of summary.rows) {
+    let result;
+    if (r.action !== 'reap') {
+      result = '—';
+    } else if (summary.dryRun) {
+      result = 'would reap';
+    } else if (r.error) {
+      result = `error: ${r.error}`;
+    } else if (r.deregistered) {
+      result = 'terminated + deregistered';
+    } else {
+      result = 'terminated';
+    }
+    lines.push(`| ${r.instanceId} | ${r.label || '—'} | ${r.action} | ${r.reason} | ${result} |`);
+  }
+  return lines.join('\n');
+}
+
+module.exports = {
+  decideReap,
+  runReaper,
+  renderCleanupSummary,
+  REAP_GRACE_MINUTES,
 };
 
 
@@ -105141,14 +105394,17 @@ class Config {
       httpTokens: core.getInput('http-tokens') || 'required',
       encryptEbs: core.getInput('encrypt-ebs') || 'false',
       cleanupOnStartFailure: core.getInput('cleanup-on-start-failure') || 'true',
+      maxLifetimeMinutes: core.getInput('max-lifetime-minutes') || '360',
+      maxAgeMinutes: core.getInput('max-age-minutes') || '120',
+      dryRun: core.getInput('dry-run') || 'false',
       debug: core.getInput('debug') || 'false',
     };
 
-    const tags = JSON.parse(core.getInput('aws-resource-tags'));
-    this.tagSpecifications = null;
-    if (tags.length > 0) {
-      this.tagSpecifications = [{ResourceType: 'instance', Tags: tags}, {ResourceType: 'volume', Tags: tags}];
-    }
+    // Raw user-supplied resource tags. The action always merges its own
+    // signature tags (managed/repository/label/started-at — see
+    // src/aws.js) on top of these so the cleanup reaper can identify
+    // instances it launched.
+    this.input.awsResourceTags = JSON.parse(core.getInput('aws-resource-tags'));
 
     // the values of github.context.repo.owner and github.context.repo.repo are taken from
     // the environment variable GITHUB_REPOSITORY specified in "owner/repo" format and
@@ -105181,8 +105437,12 @@ class Config {
       if (!this.input.label || !this.input.ec2InstanceId) {
         throw new Error(`Not all the required inputs are provided for the 'stop' mode`);
       }
+    } else if (this.input.mode === 'cleanup') {
+      // The reaper needs only the github-token (validated above) and
+      // operates on the current repository; max-age-minutes and dry-run
+      // have safe defaults.
     } else {
-      throw new Error('Wrong mode. Allowed values: start, stop.');
+      throw new Error('Wrong mode. Allowed values: start, stop, cleanup.');
     }
   }
 
@@ -105242,9 +105502,17 @@ async function getRegistrationToken() {
   }
 }
 
+// Deregister a self-hosted runner by its GitHub runner id. Idempotent
+// (DELETE), so it's retried on transient errors.
+async function deregisterRunner(runnerId) {
+  const octokit = github.getOctokit(config.input.githubToken);
+  await withRetry('remove_runner', () =>
+    octokit.request('DELETE /repos/{owner}/{repo}/actions/runners/{runner_id}', { ...config.githubContext, runner_id: runnerId }),
+  );
+}
+
 async function removeRunner() {
   const runner = await getRunner(config.input.label);
-  const octokit = github.getOctokit(config.input.githubToken);
 
   // skip the runner removal process if the runner is not found
   if (!runner) {
@@ -105256,9 +105524,7 @@ async function removeRunner() {
   const start = Date.now();
   log.info('remove_runner', { runner_id: runner.id, label: config.input.label });
   try {
-    await withRetry('remove_runner', () =>
-      octokit.request('DELETE /repos/{owner}/{repo}/actions/runners/{runner_id}', { ...config.githubContext, runner_id: runner.id }),
-    );
+    await deregisterRunner(runner.id);
     log.info('remove_runner', { runner_id: runner.id, label: config.input.label, elapsed_ms: Date.now() - start });
     core.info(`GitHub self-hosted runner ${runner.name} is removed`);
     return;
@@ -105281,7 +105547,9 @@ async function isRunnerOnline(label) {
 module.exports = {
   getRegistrationToken,
   removeRunner,
+  deregisterRunner,
   isRunnerOnline,
+  getRunner,
 };
 
 
@@ -110445,6 +110713,7 @@ const gh = __nccwpck_require__(5934);
 const config = __nccwpck_require__(1283);
 const log = __nccwpck_require__(7223);
 const { waitForRunnerReady } = __nccwpck_require__(8644);
+const { runReaper, renderCleanupSummary, REAP_GRACE_MINUTES } = __nccwpck_require__(5541);
 const core = __nccwpck_require__(7484);
 
 // Write directly to the $GITHUB_OUTPUT file. The bundled @actions/core
@@ -110523,9 +110792,55 @@ async function stop() {
   }
 }
 
+// Write the reaper's job-summary table to $GITHUB_STEP_SUMMARY (the
+// documented mechanism) and echo it to the log so it's visible even when
+// the summary file isn't set (e.g. local runs).
+function writeJobSummary(markdown) {
+  const summaryFile = process.env.GITHUB_STEP_SUMMARY;
+  if (summaryFile) {
+    fs.appendFileSync(summaryFile, `${markdown}${os.EOL}`);
+  }
+  core.info(markdown);
+}
+
+async function cleanup() {
+  core.startGroup('cleanup-runners');
+  try {
+    const repo = `${config.githubContext.owner}/${config.githubContext.repo}`;
+    const dryRun = config.input.dryRun === 'true';
+    log.info('cleanup', { repo, max_age_minutes: config.input.maxAgeMinutes, dry_run: dryRun });
+
+    const summary = await runReaper(
+      {
+        listManagedInstances: () => aws.listManagedInstances(repo),
+        getRunnerByLabel: (label) => gh.getRunner(label),
+        terminateInstance: (id) => aws.terminateInstanceById(id),
+        deregisterRunner: (runnerId) => gh.deregisterRunner(runnerId),
+        now: () => Date.now(),
+      },
+      {
+        maxAgeMinutes: Number(config.input.maxAgeMinutes),
+        graceMinutes: REAP_GRACE_MINUTES,
+        dryRun,
+      },
+    );
+
+    writeJobSummary(renderCleanupSummary(summary));
+    log.info('cleanup', { outcome: 'ok', examined: summary.examined, reaped: summary.reaped, skipped: summary.skipped, dry_run: dryRun });
+  } finally {
+    core.endGroup();
+  }
+}
+
 (async function () {
   try {
-    config.input.mode === 'start' ? await start() : await stop();
+    if (config.input.mode === 'start') {
+      await start();
+    } else if (config.input.mode === 'stop') {
+      await stop();
+    } else {
+      await cleanup();
+    }
   } catch (error) {
     log.error('fatal', { mode: config.input.mode, error: error.name, message: error.message });
     core.error(error);

--- a/docs/cleanup-workflow.yml
+++ b/docs/cleanup-workflow.yml
@@ -1,0 +1,39 @@
+# Example: scheduled reaper for leaked ec2-github-runner instances.
+#
+# Runs `mode: cleanup` on a schedule to terminate runner instances this
+# action started in THIS repository that leaked past the normal stop step
+# (cancelled workflows, runner crashes, GitHub/AWS outages mid-run). It is
+# safe to run alongside in-flight `start` jobs: instances younger than a
+# 15-minute grace floor are never reaped, and busy runners are never
+# reaped regardless of age.
+#
+# Save this as .github/workflows/cleanup-ec2-runners.yml in your repo.
+name: Cleanup leaked EC2 runners
+on:
+  schedule:
+    - cron: '*/30 * * * *' # every 30 minutes
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'List candidates without terminating anything'
+        type: boolean
+        default: false
+
+jobs:
+  cleanup:
+    name: Reap orphaned EC2 runners
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Reap leaked runners
+        uses: namecheap/ec2-github-runner@v3
+        with:
+          mode: cleanup
+          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          max-age-minutes: 120 # reap idle runners older than this
+          dry-run: ${{ inputs.dry-run || false }}

--- a/src/aws.js
+++ b/src/aws.js
@@ -1,6 +1,7 @@
 const {
   EC2Client,
   DescribeImagesCommand,
+  DescribeInstancesCommand,
   DescribeTagsCommand,
   GetConsoleOutputCommand,
   RunInstancesCommand,
@@ -19,6 +20,16 @@ const checksums = require('./runner-checksums');
 // The start action polls it to fail fast on cloud-init errors instead of
 // waiting out the full registration timeout. See buildUserData().
 const BOOTSTRAP_TAG_KEY = 'ec2-github-runner:bootstrap';
+
+// Signature tags stamped on every instance the action launches. The
+// cleanup reaper (mode: cleanup) uses managed + repository to find only
+// instances this action started in the current repo, and started-at /
+// label to make safe reap decisions. See buildTagSpecifications() and
+// listManagedInstances().
+const MANAGED_TAG_KEY = 'ec2-github-runner:managed';
+const REPO_TAG_KEY = 'ec2-github-runner:repository';
+const LABEL_TAG_KEY = 'ec2-github-runner:label';
+const STARTED_AT_TAG_KEY = 'ec2-github-runner:started-at';
 
 // Console-output capture caps: keep the printed tail useful but bounded so a
 // runaway boot log can't flood the Actions run output.
@@ -140,7 +151,23 @@ function buildEncryptedRootMapping(image) {
 //   registration timeout. Tagging is best-effort: it needs
 //   `ec2:CreateTags` on the instance profile and degrades to
 //   timeout-only detection when absent (every write is `|| true`).
-function buildUserData({ runnerVersion, owner, repo, label, githubRegistrationToken, shaX64, shaArm64 }) {
+function buildUserData({ runnerVersion, owner, repo, label, githubRegistrationToken, shaX64, shaArm64, maxLifetimeMinutes }) {
+  // TTL self-destruct (#42): arm a shutdown timer as an absolute upper
+  // bound on instance lifetime. Combined with
+  // InstanceInitiatedShutdownBehavior: terminate on RunInstances (set in
+  // startEc2Instance when enabled), the instance terminates itself even if
+  // GitHub, the workflow, and the AWS control plane all disappear. '0'
+  // disables it (no timer emitted). Best-effort: `|| true` so a missing
+  // shutdown binary never aborts the bootstrap.
+  const ttl = Number(maxLifetimeMinutes);
+  const ttlLines = Number.isFinite(ttl) && ttl > 0
+    ? [
+      '# TTL self-destruct: hard upper bound on instance lifetime (max-lifetime-minutes).',
+      `shutdown -h +${ttl} || true`,
+      '',
+    ]
+    : [];
+
   // Shared shell helpers, emitted verbatim into both the outer (root) and
   // inner (runner-user) shells — each shell re-derives instance identity
   // from IMDS so it can keep phoning home independently.
@@ -167,6 +194,7 @@ function buildUserData({ runnerVersion, owner, repo, label, githubRegistrationTo
     'GH_RUNNER_STEP=preparing',
     "trap 'gh_runner_phone_home \"failed:${GH_RUNNER_STEP}\"' ERR",
     '',
+    ...ttlLines,
     '# Root-required setup.',
     'GH_RUNNER_STEP=preparing',
     'gh_runner_phone_home preparing',
@@ -231,6 +259,31 @@ function buildUserData({ runnerVersion, owner, repo, label, githubRegistrationTo
   ].join('\n');
 }
 
+// Build the RunInstances TagSpecifications, stamping every launched
+// instance (and its volumes) with the action's signature tags on top of
+// any user-supplied aws-resource-tags. The signature lets the cleanup
+// reaper positively identify instances this action started in this repo.
+// User tags win on key collision (spread last) so callers can't be
+// silently overridden — except the reserved signature keys, which are
+// re-applied to keep the reaper's guarantees intact.
+function buildTagSpecifications(label, startedAtIso) {
+  const owner = config.githubContext.owner;
+  const repo = config.githubContext.repo;
+  const userTags = config.input.awsResourceTags || [];
+  const signatureKeys = new Set([MANAGED_TAG_KEY, REPO_TAG_KEY, LABEL_TAG_KEY, STARTED_AT_TAG_KEY]);
+  const tags = [
+    ...userTags.filter((t) => !signatureKeys.has(t.Key)),
+    { Key: MANAGED_TAG_KEY, Value: 'true' },
+    { Key: REPO_TAG_KEY, Value: `${owner}/${repo}` },
+    { Key: LABEL_TAG_KEY, Value: label },
+    { Key: STARTED_AT_TAG_KEY, Value: startedAtIso },
+  ];
+  return [
+    { ResourceType: 'instance', Tags: tags },
+    { ResourceType: 'volume', Tags: tags },
+  ];
+}
+
 async function startEc2Instance(label, githubRegistrationToken) {
   const client = ec2Client();
 
@@ -247,7 +300,8 @@ async function startEc2Instance(label, githubRegistrationToken) {
     );
   }
 
-  const userData = buildUserData({ runnerVersion, owner, repo, label, githubRegistrationToken, shaX64, shaArm64 });
+  const maxLifetimeMinutes = config.input.maxLifetimeMinutes;
+  const userData = buildUserData({ runnerVersion, owner, repo, label, githubRegistrationToken, shaX64, shaArm64, maxLifetimeMinutes });
 
   const resolved = await resolveImage(client);
   config.input.ec2ImageId = resolved.id;
@@ -261,7 +315,7 @@ async function startEc2Instance(label, githubRegistrationToken) {
     SubnetId: config.input.subnetId,
     SecurityGroupIds: [config.input.securityGroupId],
     IamInstanceProfile: { Name: config.input.iamRoleName },
-    TagSpecifications: config.tagSpecifications,
+    TagSpecifications: buildTagSpecifications(label, new Date().toISOString()),
     // IMDSv2 required by default. Mitigates SSRF-style IAM credential
     // theft from the runner — any metadata request must present a
     // session token. HttpPutResponseHopLimit: 1 prevents the token
@@ -272,6 +326,14 @@ async function startEc2Instance(label, githubRegistrationToken) {
       HttpEndpoint: 'enabled',
     },
   };
+
+  // TTL self-destruct: terminate (not stop) when the in-instance shutdown
+  // timer fires, so the hard lifetime bound actually frees the instance.
+  // Only set when the timer is armed (max-lifetime-minutes != 0) to keep
+  // the default launch behavior unchanged.
+  if (Number(maxLifetimeMinutes) > 0) {
+    params.InstanceInitiatedShutdownBehavior = 'terminate';
+  }
 
   if (config.input.encryptEbs === 'true') {
     const mappings = buildEncryptedRootMapping(resolved.image);
@@ -448,6 +510,48 @@ async function handleStartFailure(ec2InstanceId, opts = {}) {
   }
 }
 
+// List running/pending instances this action launched in the given repo,
+// for the cleanup reaper. Filtering is server-side on the full signature
+// (managed=true AND repository=repo) and re-validated client-side (belt-
+// and-braces: only instances carrying both signature tags are ever
+// returned, so a near-miss tag set can never be reaped). Each result
+// carries the parsed started-at (ms; falls back to LaunchTime) and label
+// the reaper needs to make its decision.
+async function listManagedInstances(repo) {
+  const client = ec2Client();
+  const resp = await client.send(new DescribeInstancesCommand({
+    Filters: [
+      { Name: `tag:${MANAGED_TAG_KEY}`, Values: ['true'] },
+      { Name: `tag:${REPO_TAG_KEY}`, Values: [repo] },
+      { Name: 'instance-state-name', Values: ['pending', 'running'] },
+    ],
+  }));
+
+  const instances = [];
+  for (const reservation of resp.Reservations || []) {
+    for (const instance of reservation.Instances || []) {
+      const tags = {};
+      for (const tag of instance.Tags || []) {
+        tags[tag.Key] = tag.Value;
+      }
+      // Client-side re-validation of the full signature.
+      if (tags[MANAGED_TAG_KEY] !== 'true' || tags[REPO_TAG_KEY] !== repo) {
+        continue;
+      }
+      const startedAtRaw = tags[STARTED_AT_TAG_KEY];
+      const startedAtMs = startedAtRaw && !Number.isNaN(Date.parse(startedAtRaw))
+        ? Date.parse(startedAtRaw)
+        : (instance.LaunchTime ? new Date(instance.LaunchTime).getTime() : null);
+      instances.push({
+        instanceId: instance.InstanceId,
+        label: tags[LABEL_TAG_KEY] || null,
+        startedAtMs,
+      });
+    }
+  }
+  return instances;
+}
+
 module.exports = {
   startEc2Instance,
   terminateEc2Instance,
@@ -456,9 +560,15 @@ module.exports = {
   getBootstrapStatus,
   getConsoleOutputTail,
   handleStartFailure,
+  listManagedInstances,
   // Exported for unit testing.
   buildEncryptedRootMapping,
   buildUserData,
+  buildTagSpecifications,
   redactSecrets,
   BOOTSTRAP_TAG_KEY,
+  MANAGED_TAG_KEY,
+  REPO_TAG_KEY,
+  LABEL_TAG_KEY,
+  STARTED_AT_TAG_KEY,
 };

--- a/src/cleanup.js
+++ b/src/cleanup.js
@@ -1,0 +1,136 @@
+const log = require('./log');
+
+// Instances younger than this are never reaped, even if no runner is
+// registered for them yet — they may be in-flight starts still working
+// through the bootstrap/registration window. Keeps the reaper safe to run
+// concurrently with `mode: start`.
+const REAP_GRACE_MINUTES = 15;
+
+// Decide what to do with a single managed instance given its matching
+// GitHub runner (or null if none is registered). Pure function — no I/O —
+// so the full decision matrix is unit-testable.
+//
+//   within grace period         -> skip  (protect in-flight starts)
+//   no runner registered        -> reap  (leaked instance)
+//   runner busy                 -> skip  (job in progress, any age)
+//   runner idle, older than max -> reap + deregister
+//   runner idle, within max age  -> skip
+function decideReap(instance, runner, opts) {
+  const { nowMs, maxAgeMinutes, graceMinutes } = opts;
+  const ageMinutes = instance.startedAtMs != null ? (nowMs - instance.startedAtMs) / 60000 : Infinity;
+
+  if (ageMinutes < graceMinutes) {
+    return { action: 'skip', reason: 'within-grace-period', deregister: false };
+  }
+  if (!runner) {
+    return { action: 'reap', reason: 'runner-not-registered', deregister: false };
+  }
+  if (runner.busy) {
+    return { action: 'skip', reason: 'runner-busy', deregister: false };
+  }
+  if (ageMinutes > maxAgeMinutes) {
+    return { action: 'reap', reason: 'runner-idle-past-max-age', deregister: true };
+  }
+  return { action: 'skip', reason: 'runner-idle-within-max-age', deregister: false };
+}
+
+// Walk every managed instance in the repo, decide, and (unless dryRun)
+// terminate + deregister the ones that should be reaped. All AWS/GitHub
+// I/O and the clock are injected via deps so the orchestration is
+// testable end-to-end with mocks:
+//   deps.listManagedInstances(): Promise<Array<{instanceId,label,startedAtMs}>>
+//   deps.getRunnerByLabel(label): Promise<runner|null>
+//   deps.terminateInstance(id): Promise<void>
+//   deps.deregisterRunner(runnerId): Promise<void>
+//   deps.now(): number (ms)
+// A single instance failing to terminate/deregister is recorded on its row
+// and does not abort the sweep.
+async function runReaper(deps, opts = {}) {
+  const { listManagedInstances, getRunnerByLabel, terminateInstance, deregisterRunner, now } = deps;
+  const maxAgeMinutes = opts.maxAgeMinutes;
+  const graceMinutes = opts.graceMinutes ?? REAP_GRACE_MINUTES;
+  const dryRun = !!opts.dryRun;
+
+  const instances = await listManagedInstances();
+  const nowMs = now();
+  const rows = [];
+  let reaped = 0;
+  let skipped = 0;
+
+  for (const instance of instances) {
+    const runner = instance.label ? await getRunnerByLabel(instance.label) : null;
+    const decision = decideReap(instance, runner, { nowMs, maxAgeMinutes, graceMinutes });
+    const row = {
+      instanceId: instance.instanceId,
+      label: instance.label,
+      action: decision.action,
+      reason: decision.reason,
+      performed: false,
+    };
+
+    if (decision.action === 'reap') {
+      reaped += 1;
+      if (!dryRun) {
+        try {
+          await terminateInstance(instance.instanceId);
+          row.performed = true;
+          if (decision.deregister && runner) {
+            try {
+              await deregisterRunner(runner.id);
+              row.deregistered = true;
+            } catch (error) {
+              row.deregisterError = error.message;
+              log.error('reaper_deregister', { instance_id: instance.instanceId, runner_id: runner.id, error: error.name, message: error.message });
+            }
+          }
+        } catch (error) {
+          row.error = error.message;
+          log.error('reaper_terminate', { instance_id: instance.instanceId, error: error.name, message: error.message });
+        }
+      }
+    } else {
+      skipped += 1;
+    }
+
+    log.info('reaper_decision', { instance_id: instance.instanceId, label: instance.label, action: decision.action, reason: decision.reason, dry_run: dryRun });
+    rows.push(row);
+  }
+
+  return { examined: instances.length, reaped, skipped, dryRun, rows };
+}
+
+// Render the reaper result as a GitHub Actions job-summary markdown table.
+function renderCleanupSummary(summary) {
+  const heading = summary.dryRun ? 'EC2 runner cleanup (dry-run)' : 'EC2 runner cleanup';
+  const lines = [
+    `### ${heading}`,
+    '',
+    `Examined: **${summary.examined}** · Reaped: **${summary.reaped}** · Skipped: **${summary.skipped}**`,
+    '',
+    '| Instance | Label | Action | Reason | Result |',
+    '| --- | --- | --- | --- | --- |',
+  ];
+  for (const r of summary.rows) {
+    let result;
+    if (r.action !== 'reap') {
+      result = '—';
+    } else if (summary.dryRun) {
+      result = 'would reap';
+    } else if (r.error) {
+      result = `error: ${r.error}`;
+    } else if (r.deregistered) {
+      result = 'terminated + deregistered';
+    } else {
+      result = 'terminated';
+    }
+    lines.push(`| ${r.instanceId} | ${r.label || '—'} | ${r.action} | ${r.reason} | ${result} |`);
+  }
+  return lines.join('\n');
+}
+
+module.exports = {
+  decideReap,
+  runReaper,
+  renderCleanupSummary,
+  REAP_GRACE_MINUTES,
+};

--- a/src/config.js
+++ b/src/config.js
@@ -20,14 +20,17 @@ class Config {
       httpTokens: core.getInput('http-tokens') || 'required',
       encryptEbs: core.getInput('encrypt-ebs') || 'false',
       cleanupOnStartFailure: core.getInput('cleanup-on-start-failure') || 'true',
+      maxLifetimeMinutes: core.getInput('max-lifetime-minutes') || '360',
+      maxAgeMinutes: core.getInput('max-age-minutes') || '120',
+      dryRun: core.getInput('dry-run') || 'false',
       debug: core.getInput('debug') || 'false',
     };
 
-    const tags = JSON.parse(core.getInput('aws-resource-tags'));
-    this.tagSpecifications = null;
-    if (tags.length > 0) {
-      this.tagSpecifications = [{ResourceType: 'instance', Tags: tags}, {ResourceType: 'volume', Tags: tags}];
-    }
+    // Raw user-supplied resource tags. The action always merges its own
+    // signature tags (managed/repository/label/started-at — see
+    // src/aws.js) on top of these so the cleanup reaper can identify
+    // instances it launched.
+    this.input.awsResourceTags = JSON.parse(core.getInput('aws-resource-tags'));
 
     // the values of github.context.repo.owner and github.context.repo.repo are taken from
     // the environment variable GITHUB_REPOSITORY specified in "owner/repo" format and
@@ -60,8 +63,12 @@ class Config {
       if (!this.input.label || !this.input.ec2InstanceId) {
         throw new Error(`Not all the required inputs are provided for the 'stop' mode`);
       }
+    } else if (this.input.mode === 'cleanup') {
+      // The reaper needs only the github-token (validated above) and
+      // operates on the current repository; max-age-minutes and dry-run
+      // have safe defaults.
     } else {
-      throw new Error('Wrong mode. Allowed values: start, stop.');
+      throw new Error('Wrong mode. Allowed values: start, stop, cleanup.');
     }
   }
 

--- a/src/gh.js
+++ b/src/gh.js
@@ -36,9 +36,17 @@ async function getRegistrationToken() {
   }
 }
 
+// Deregister a self-hosted runner by its GitHub runner id. Idempotent
+// (DELETE), so it's retried on transient errors.
+async function deregisterRunner(runnerId) {
+  const octokit = github.getOctokit(config.input.githubToken);
+  await withRetry('remove_runner', () =>
+    octokit.request('DELETE /repos/{owner}/{repo}/actions/runners/{runner_id}', { ...config.githubContext, runner_id: runnerId }),
+  );
+}
+
 async function removeRunner() {
   const runner = await getRunner(config.input.label);
-  const octokit = github.getOctokit(config.input.githubToken);
 
   // skip the runner removal process if the runner is not found
   if (!runner) {
@@ -50,9 +58,7 @@ async function removeRunner() {
   const start = Date.now();
   log.info('remove_runner', { runner_id: runner.id, label: config.input.label });
   try {
-    await withRetry('remove_runner', () =>
-      octokit.request('DELETE /repos/{owner}/{repo}/actions/runners/{runner_id}', { ...config.githubContext, runner_id: runner.id }),
-    );
+    await deregisterRunner(runner.id);
     log.info('remove_runner', { runner_id: runner.id, label: config.input.label, elapsed_ms: Date.now() - start });
     core.info(`GitHub self-hosted runner ${runner.name} is removed`);
     return;
@@ -75,5 +81,7 @@ async function isRunnerOnline(label) {
 module.exports = {
   getRegistrationToken,
   removeRunner,
+  deregisterRunner,
   isRunnerOnline,
+  getRunner,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ const gh = require('./gh');
 const config = require('./config');
 const log = require('./log');
 const { waitForRunnerReady } = require('./wait');
+const { runReaper, renderCleanupSummary, REAP_GRACE_MINUTES } = require('./cleanup');
 const core = require('@actions/core');
 
 // Write directly to the $GITHUB_OUTPUT file. The bundled @actions/core
@@ -98,9 +99,55 @@ async function stop() {
   }
 }
 
+// Write the reaper's job-summary table to $GITHUB_STEP_SUMMARY (the
+// documented mechanism) and echo it to the log so it's visible even when
+// the summary file isn't set (e.g. local runs).
+function writeJobSummary(markdown) {
+  const summaryFile = process.env.GITHUB_STEP_SUMMARY;
+  if (summaryFile) {
+    fs.appendFileSync(summaryFile, `${markdown}${os.EOL}`);
+  }
+  core.info(markdown);
+}
+
+async function cleanup() {
+  core.startGroup('cleanup-runners');
+  try {
+    const repo = `${config.githubContext.owner}/${config.githubContext.repo}`;
+    const dryRun = config.input.dryRun === 'true';
+    log.info('cleanup', { repo, max_age_minutes: config.input.maxAgeMinutes, dry_run: dryRun });
+
+    const summary = await runReaper(
+      {
+        listManagedInstances: () => aws.listManagedInstances(repo),
+        getRunnerByLabel: (label) => gh.getRunner(label),
+        terminateInstance: (id) => aws.terminateInstanceById(id),
+        deregisterRunner: (runnerId) => gh.deregisterRunner(runnerId),
+        now: () => Date.now(),
+      },
+      {
+        maxAgeMinutes: Number(config.input.maxAgeMinutes),
+        graceMinutes: REAP_GRACE_MINUTES,
+        dryRun,
+      },
+    );
+
+    writeJobSummary(renderCleanupSummary(summary));
+    log.info('cleanup', { outcome: 'ok', examined: summary.examined, reaped: summary.reaped, skipped: summary.skipped, dry_run: dryRun });
+  } finally {
+    core.endGroup();
+  }
+}
+
 (async function () {
   try {
-    config.input.mode === 'start' ? await start() : await stop();
+    if (config.input.mode === 'start') {
+      await start();
+    } else if (config.input.mode === 'stop') {
+      await stop();
+    } else {
+      await cleanup();
+    }
   } catch (error) {
     log.error('fatal', { mode: config.input.mode, error: error.name, message: error.message });
     core.error(error);

--- a/tests/cleanup.test.js
+++ b/tests/cleanup.test.js
@@ -1,0 +1,134 @@
+// Tests for the cleanup reaper: the pure decideReap decision matrix, the
+// injectable runReaper orchestration, and renderCleanupSummary. log.js is
+// reached transitively, so config + core are mocked to keep it quiet.
+jest.mock('../src/config', () => ({ input: { mode: 'cleanup', debug: 'false' } }));
+jest.mock('@actions/core', () => ({ info: jest.fn(), warning: jest.fn(), error: jest.fn(), debug: jest.fn() }));
+
+const { decideReap, runReaper, renderCleanupSummary, REAP_GRACE_MINUTES } = require('../src/cleanup');
+
+const NOW = Date.parse('2026-07-02T18:00:00.000Z');
+const minutesAgo = (m) => NOW - m * 60000;
+const opts = { nowMs: NOW, maxAgeMinutes: 120, graceMinutes: REAP_GRACE_MINUTES };
+
+describe('decideReap — decision matrix', () => {
+  test('skips instances still within the grace period', () => {
+    const d = decideReap({ startedAtMs: minutesAgo(5) }, null, opts);
+    expect(d).toMatchObject({ action: 'skip', reason: 'within-grace-period' });
+  });
+
+  test('reaps an old instance whose runner is not registered (no deregister)', () => {
+    const d = decideReap({ startedAtMs: minutesAgo(200) }, null, opts);
+    expect(d).toMatchObject({ action: 'reap', reason: 'runner-not-registered', deregister: false });
+  });
+
+  test('never reaps a busy runner, regardless of age', () => {
+    const d = decideReap({ startedAtMs: minutesAgo(10000) }, { id: 1, busy: true }, opts);
+    expect(d).toMatchObject({ action: 'skip', reason: 'runner-busy' });
+  });
+
+  test('reaps and deregisters an idle runner past max-age', () => {
+    const d = decideReap({ startedAtMs: minutesAgo(200) }, { id: 1, busy: false }, opts);
+    expect(d).toMatchObject({ action: 'reap', reason: 'runner-idle-past-max-age', deregister: true });
+  });
+
+  test('skips an idle runner still within max-age', () => {
+    const d = decideReap({ startedAtMs: minutesAgo(60) }, { id: 1, busy: false }, opts);
+    expect(d).toMatchObject({ action: 'skip', reason: 'runner-idle-within-max-age' });
+  });
+});
+
+function fixtures() {
+  const instances = [
+    { instanceId: 'i-a', label: 'a', startedAtMs: minutesAgo(200) }, // runner gone -> reap
+    { instanceId: 'i-b', label: 'b', startedAtMs: minutesAgo(200) }, // busy -> skip
+    { instanceId: 'i-c', label: 'c', startedAtMs: minutesAgo(200) }, // idle old -> reap + deregister
+    { instanceId: 'i-d', label: 'd', startedAtMs: minutesAgo(5) },   // grace -> skip
+    { instanceId: 'i-e', label: 'e', startedAtMs: minutesAgo(60) },  // idle young -> skip
+  ];
+  const runners = { a: null, b: { id: 2, busy: true }, c: { id: 3, busy: false }, d: { id: 4, busy: false }, e: { id: 5, busy: false } };
+  return { instances, runners };
+}
+
+describe('runReaper', () => {
+  test('terminates and deregisters exactly the right instances (live run)', async () => {
+    const { instances, runners } = fixtures();
+    const terminateInstance = jest.fn().mockResolvedValue();
+    const deregisterRunner = jest.fn().mockResolvedValue();
+
+    const summary = await runReaper({
+      listManagedInstances: () => Promise.resolve(instances),
+      getRunnerByLabel: (l) => Promise.resolve(runners[l]),
+      terminateInstance,
+      deregisterRunner,
+      now: () => NOW,
+    }, { maxAgeMinutes: 120, dryRun: false });
+
+    expect(terminateInstance.mock.calls.map((c) => c[0]).sort()).toEqual(['i-a', 'i-c']);
+    expect(deregisterRunner.mock.calls.map((c) => c[0])).toEqual([3]); // only the idle-old one
+    expect(summary).toMatchObject({ examined: 5, reaped: 2, skipped: 3, dryRun: false });
+  });
+
+  test('dry-run acts on nothing but still lists candidates', async () => {
+    const { instances, runners } = fixtures();
+    const terminateInstance = jest.fn().mockResolvedValue();
+    const deregisterRunner = jest.fn().mockResolvedValue();
+
+    const summary = await runReaper({
+      listManagedInstances: () => Promise.resolve(instances),
+      getRunnerByLabel: (l) => Promise.resolve(runners[l]),
+      terminateInstance,
+      deregisterRunner,
+      now: () => NOW,
+    }, { maxAgeMinutes: 120, dryRun: true });
+
+    expect(terminateInstance).not.toHaveBeenCalled();
+    expect(deregisterRunner).not.toHaveBeenCalled();
+    expect(summary).toMatchObject({ examined: 5, reaped: 2, skipped: 3, dryRun: true });
+    expect(summary.rows.filter((r) => r.action === 'reap').every((r) => r.performed === false)).toBe(true);
+  });
+
+  test('a termination failure is recorded and does not abort the sweep', async () => {
+    const instances = [
+      { instanceId: 'i-x', label: 'x', startedAtMs: minutesAgo(200) },
+      { instanceId: 'i-y', label: 'y', startedAtMs: minutesAgo(200) },
+    ];
+    const terminateInstance = jest.fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce();
+
+    const summary = await runReaper({
+      listManagedInstances: () => Promise.resolve(instances),
+      getRunnerByLabel: () => Promise.resolve(null),
+      terminateInstance,
+      deregisterRunner: jest.fn(),
+      now: () => NOW,
+    }, { maxAgeMinutes: 120, dryRun: false });
+
+    expect(terminateInstance).toHaveBeenCalledTimes(2);
+    expect(summary.rows[0]).toMatchObject({ instanceId: 'i-x', error: 'boom' });
+    expect(summary.rows[1]).toMatchObject({ instanceId: 'i-y', performed: true });
+  });
+});
+
+describe('renderCleanupSummary', () => {
+  test('renders a dry-run table with "would reap"', () => {
+    const md = renderCleanupSummary({
+      examined: 1, reaped: 1, skipped: 0, dryRun: true,
+      rows: [{ instanceId: 'i-a', label: 'a', action: 'reap', reason: 'runner-not-registered' }],
+    });
+    expect(md).toContain('dry-run');
+    expect(md).toContain('| i-a | a | reap | runner-not-registered | would reap |');
+  });
+
+  test('renders a live table distinguishing terminate vs terminate+deregister', () => {
+    const md = renderCleanupSummary({
+      examined: 2, reaped: 2, skipped: 0, dryRun: false,
+      rows: [
+        { instanceId: 'i-a', label: 'a', action: 'reap', reason: 'runner-not-registered', performed: true },
+        { instanceId: 'i-c', label: 'c', action: 'reap', reason: 'runner-idle-past-max-age', performed: true, deregistered: true },
+      ],
+    });
+    expect(md).toContain('| i-a | a | reap | runner-not-registered | terminated |');
+    expect(md).toContain('| i-c | c | reap | runner-idle-past-max-age | terminated + deregistered |');
+  });
+});

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -60,19 +60,15 @@ describe('Config — start mode', () => {
     expect(config.githubContext).toEqual({ owner: 'namecheap', repo: 'ec2-github-runner' });
   });
 
-  test('builds tagSpecifications for instance and volume when tags provided', () => {
+  test('parses aws-resource-tags into the awsResourceTags array', () => {
     const tags = [{ Key: 'Owner', Value: 'devops' }];
     const config = loadConfig({ ...startModeInputs, 'aws-resource-tags': JSON.stringify(tags) });
-
-    expect(config.tagSpecifications).toHaveLength(2);
-    expect(config.tagSpecifications[0].ResourceType).toBe('instance');
-    expect(config.tagSpecifications[1].ResourceType).toBe('volume');
-    expect(config.tagSpecifications[0].Tags).toEqual(tags);
+    expect(config.input.awsResourceTags).toEqual(tags);
   });
 
-  test('tagSpecifications is null when aws-resource-tags is empty list', () => {
+  test('awsResourceTags is an empty array when aws-resource-tags is empty list', () => {
     const config = loadConfig({ ...startModeInputs, 'aws-resource-tags': '[]' });
-    expect(config.tagSpecifications).toBeNull();
+    expect(config.input.awsResourceTags).toEqual([]);
   });
 
   test('reports missing mode via core.setFailed', () => {
@@ -127,7 +123,44 @@ describe('Config — stop mode', () => {
 
 describe('Config — mode validation', () => {
   test('reports unknown mode via core.setFailed', () => {
-    expectValidationFailure({ ...startModeInputs, 'mode': 'restart' }, /Wrong mode. Allowed values: start, stop/);
+    expectValidationFailure({ ...startModeInputs, 'mode': 'restart' }, /Wrong mode. Allowed values: start, stop, cleanup/);
+  });
+});
+
+describe('Config — cleanup mode', () => {
+  const cleanupModeInputs = {
+    'mode': 'cleanup',
+    'github-token': 'ghs_testtoken',
+    'aws-resource-tags': '[]',
+  };
+
+  test('valid inputs produce a config with defaulted cleanup knobs', () => {
+    const config = loadConfig(cleanupModeInputs);
+    expect(config.input.mode).toBe('cleanup');
+    expect(config.input.maxAgeMinutes).toBe('120');
+    expect(config.input.dryRun).toBe('false');
+  });
+
+  test('honors max-age-minutes and dry-run overrides', () => {
+    const config = loadConfig({ ...cleanupModeInputs, 'max-age-minutes': '30', 'dry-run': 'true' });
+    expect(config.input.maxAgeMinutes).toBe('30');
+    expect(config.input.dryRun).toBe('true');
+  });
+
+  test('still requires github-token', () => {
+    expectValidationFailure({ ...cleanupModeInputs, 'github-token': '' }, /'github-token' input is not specified/);
+  });
+});
+
+describe('Config — max-lifetime-minutes input', () => {
+  test('defaults to 360 when unset', () => {
+    const config = loadConfig(startModeInputs);
+    expect(config.input.maxLifetimeMinutes).toBe('360');
+  });
+
+  test('honors an explicit override, including 0 to disable', () => {
+    expect(loadConfig({ ...startModeInputs, 'max-lifetime-minutes': '720' }).input.maxLifetimeMinutes).toBe('720');
+    expect(loadConfig({ ...startModeInputs, 'max-lifetime-minutes': '0' }).input.maxLifetimeMinutes).toBe('0');
   });
 });
 

--- a/tests/tags.test.js
+++ b/tests/tags.test.js
@@ -1,0 +1,138 @@
+// Tests for the signature-tag machinery: buildTagSpecifications (stamped
+// onto every launched instance) and listManagedInstances (the reaper's
+// filter + client-side re-validation). The EC2 client is mocked so the
+// DescribeInstances filters and the near-miss safety guard can be asserted.
+const mockSend = jest.fn();
+jest.mock('@aws-sdk/client-ec2', () => ({
+  EC2Client: jest.fn(() => ({ send: mockSend })),
+  DescribeImagesCommand: jest.fn((p) => ({ __command: 'DescribeImages', ...p })),
+  DescribeInstancesCommand: jest.fn((p) => ({ __command: 'DescribeInstances', ...p })),
+  DescribeTagsCommand: jest.fn((p) => ({ __command: 'DescribeTags', ...p })),
+  GetConsoleOutputCommand: jest.fn((p) => ({ __command: 'GetConsoleOutput', ...p })),
+  RunInstancesCommand: jest.fn((p) => ({ __command: 'RunInstances', ...p })),
+  TerminateInstancesCommand: jest.fn((p) => ({ __command: 'TerminateInstances', ...p })),
+  AssociateAddressCommand: jest.fn((p) => ({ __command: 'AssociateAddress', ...p })),
+  waitUntilInstanceRunning: jest.fn(),
+}));
+jest.mock('../src/config', () => ({
+  input: { mode: 'start', debug: 'false', awsResourceTags: [] },
+  githubContext: { owner: 'my-org', repo: 'my-repo' },
+}));
+jest.mock('@actions/core', () => ({
+  info: jest.fn(), warning: jest.fn(), error: jest.fn(), setFailed: jest.fn(),
+  getInput: jest.fn(), startGroup: jest.fn(), endGroup: jest.fn(), debug: jest.fn(),
+}));
+
+const config = require('../src/config');
+const aws = require('../src/aws');
+
+const tagsOf = (spec) => {
+  const out = {};
+  for (const t of spec.Tags) out[t.Key] = t.Value;
+  return out;
+};
+
+beforeEach(() => {
+  mockSend.mockReset();
+  config.input.awsResourceTags = [];
+});
+
+describe('buildTagSpecifications', () => {
+  test('stamps the full signature on both instance and volume', () => {
+    const specs = aws.buildTagSpecifications('runner-abc12', '2026-07-02T18:00:00.000Z');
+    expect(specs.map((s) => s.ResourceType)).toEqual(['instance', 'volume']);
+    for (const spec of specs) {
+      const t = tagsOf(spec);
+      expect(t[aws.MANAGED_TAG_KEY]).toBe('true');
+      expect(t[aws.REPO_TAG_KEY]).toBe('my-org/my-repo');
+      expect(t[aws.LABEL_TAG_KEY]).toBe('runner-abc12');
+      expect(t[aws.STARTED_AT_TAG_KEY]).toBe('2026-07-02T18:00:00.000Z');
+    }
+  });
+
+  test('merges user-supplied tags alongside the signature', () => {
+    config.input.awsResourceTags = [{ Key: 'Owner', Value: 'devops' }];
+    const t = tagsOf(aws.buildTagSpecifications('l', 'ts')[0]);
+    expect(t.Owner).toBe('devops');
+    expect(t[aws.MANAGED_TAG_KEY]).toBe('true');
+  });
+
+  test('never lets a user tag override a reserved signature key', () => {
+    config.input.awsResourceTags = [{ Key: aws.MANAGED_TAG_KEY, Value: 'false' }, { Key: aws.REPO_TAG_KEY, Value: 'evil/repo' }];
+    const t = tagsOf(aws.buildTagSpecifications('l', 'ts')[0]);
+    expect(t[aws.MANAGED_TAG_KEY]).toBe('true');
+    expect(t[aws.REPO_TAG_KEY]).toBe('my-org/my-repo');
+    // and only one entry per reserved key
+    const managedCount = aws.buildTagSpecifications('l', 'ts')[0].Tags.filter((x) => x.Key === aws.MANAGED_TAG_KEY).length;
+    expect(managedCount).toBe(1);
+  });
+});
+
+describe('listManagedInstances', () => {
+  test('filters server-side on managed + repository + running state', async () => {
+    mockSend.mockResolvedValueOnce({ Reservations: [] });
+    await aws.listManagedInstances('my-org/my-repo');
+    const cmd = mockSend.mock.calls[0][0];
+    expect(cmd.__command).toBe('DescribeInstances');
+    expect(cmd.Filters).toEqual([
+      { Name: `tag:${aws.MANAGED_TAG_KEY}`, Values: ['true'] },
+      { Name: `tag:${aws.REPO_TAG_KEY}`, Values: ['my-org/my-repo'] },
+      { Name: 'instance-state-name', Values: ['pending', 'running'] },
+    ]);
+  });
+
+  test('returns instance id, label, and parsed started-at', async () => {
+    mockSend.mockResolvedValueOnce({
+      Reservations: [{
+        Instances: [{
+          InstanceId: 'i-1',
+          LaunchTime: '2026-07-02T10:00:00.000Z',
+          Tags: [
+            { Key: aws.MANAGED_TAG_KEY, Value: 'true' },
+            { Key: aws.REPO_TAG_KEY, Value: 'my-org/my-repo' },
+            { Key: aws.LABEL_TAG_KEY, Value: 'runner-xyz' },
+            { Key: aws.STARTED_AT_TAG_KEY, Value: '2026-07-02T12:00:00.000Z' },
+          ],
+        }],
+      }],
+    });
+    const result = await aws.listManagedInstances('my-org/my-repo');
+    expect(result).toEqual([{ instanceId: 'i-1', label: 'runner-xyz', startedAtMs: Date.parse('2026-07-02T12:00:00.000Z') }]);
+  });
+
+  test('falls back to LaunchTime when started-at tag is missing', async () => {
+    mockSend.mockResolvedValueOnce({
+      Reservations: [{
+        Instances: [{
+          InstanceId: 'i-2',
+          LaunchTime: '2026-07-02T10:00:00.000Z',
+          Tags: [
+            { Key: aws.MANAGED_TAG_KEY, Value: 'true' },
+            { Key: aws.REPO_TAG_KEY, Value: 'my-org/my-repo' },
+          ],
+        }],
+      }],
+    });
+    const result = await aws.listManagedInstances('my-org/my-repo');
+    expect(result[0].startedAtMs).toBe(Date.parse('2026-07-02T10:00:00.000Z'));
+    expect(result[0].label).toBeNull();
+  });
+
+  test('SAFETY: excludes near-miss instances the server filter might return', async () => {
+    // Defense in depth: even if a malformed DescribeInstances response
+    // surfaced instances without the full signature, they must not be
+    // eligible for reaping.
+    mockSend.mockResolvedValueOnce({
+      Reservations: [{
+        Instances: [
+          { InstanceId: 'i-good', Tags: [{ Key: aws.MANAGED_TAG_KEY, Value: 'true' }, { Key: aws.REPO_TAG_KEY, Value: 'my-org/my-repo' }] },
+          { InstanceId: 'i-wrong-repo', Tags: [{ Key: aws.MANAGED_TAG_KEY, Value: 'true' }, { Key: aws.REPO_TAG_KEY, Value: 'other/repo' }] },
+          { InstanceId: 'i-not-managed', Tags: [{ Key: aws.REPO_TAG_KEY, Value: 'my-org/my-repo' }] },
+          { InstanceId: 'i-untagged', Tags: [] },
+        ],
+      }],
+    });
+    const result = await aws.listManagedInstances('my-org/my-repo');
+    expect(result.map((r) => r.instanceId)).toEqual(['i-good']);
+  });
+});

--- a/tests/userdata.test.js
+++ b/tests/userdata.test.js
@@ -88,4 +88,19 @@ describe('buildUserData', () => {
     const ud = buildUserData(args);
     expect(ud).toContain('--ephemeral --unattended --disableupdate');
   });
+
+  test('arms a TTL self-destruct shutdown when max-lifetime-minutes > 0', () => {
+    const ud = buildUserData({ ...args, maxLifetimeMinutes: '360' });
+    expect(ud).toContain('shutdown -h +360 || true');
+  });
+
+  test('omits the TTL shutdown when max-lifetime-minutes is 0', () => {
+    const ud = buildUserData({ ...args, maxLifetimeMinutes: '0' });
+    expect(ud).not.toContain('shutdown -h');
+  });
+
+  test('omits the TTL shutdown when max-lifetime-minutes is unset', () => {
+    const ud = buildUserData(args);
+    expect(ud).not.toContain('shutdown -h');
+  });
 });


### PR DESCRIPTION
Closes #42 — roadmap (#49) Phase 1, second item; builds on the signature tagging introduced alongside #41.

## Problem
`stop` runs `if: always()`, but leaks still happen: cancelled workflows where stop never scheduled, runner crashes, GitHub/AWS outages mid-run, or the workflow killed after `start` but before `stop`. Nothing today even *lists* the instances this action started. Two independent, defense-in-depth layers close every known leak path.

## 1. TTL self-destruct — `max-lifetime-minutes` (default 360, `0` disables)
- User-data arms `shutdown -h +N`; the instance launches with `InstanceInitiatedShutdownBehavior=terminate`, so it **self-terminates at the TTL even if GitHub, the workflow, and the AWS control plane all disappear**.
- Absolute upper bound, not the normal path. README documents sizing (set above your longest job).

## 2. `mode: cleanup` — the reaper
- Finds instances **this action started in the current repo** via its full signature tag set (`ec2-github-runner:managed`/`:repository`/`:label`/`:started-at`, now stamped on **every** launched instance), cross-checks each against the GitHub runners API:

  | Runner state | Action |
  | --- | --- |
  | younger than 15-min grace floor | skip (in-flight start) |
  | no runner registered | reap |
  | runner busy | skip (any age) |
  | idle, older than `max-age-minutes` | reap + deregister |
  | idle, within `max-age-minutes` | skip |

- `dry-run: true` lists candidates without acting. Job-summary table reports examined/reaped/skipped with reasons.
- Example scheduled workflow: `docs/cleanup-workflow.yml`.

## Safety
- Reaper matches **only** the full signature in the current repo — server-side DescribeInstances filter **and** client-side re-validation (near-miss tag sets can never be reaped; explicit test).
- 15-min grace floor makes it safe to run concurrently with `start`.
- Busy runners never reaped. Per-instance terminate/deregister failures are recorded and don't abort the sweep.
- Reserved signature tag keys can't be overridden by user `aws-resource-tags`.

## Tests / build
- `tests/cleanup.test.js` (decision matrix + orchestration + dry-run + summary), `tests/tags.test.js` (signature merge + reaper safety + filter), TTL user-data + config tests. **108 tests pass** (was 83). Lint clean, dist rebuilt (verify-dist green).

## IAM
- `ec2:CreateTags` at launch is now always required (signature tags on every instance) — documented. Reaper reuses base `ec2:DescribeInstances` + `ec2:TerminateInstances`; deregisters via `github-token`.

## Compatibility
- Existing inputs unchanged. New: `max-lifetime-minutes` (start), `max-age-minutes` + `dry-run` (cleanup), plus `mode: cleanup`.