### PR TITLE
feat: root volume configuration (volume-size/type/iops/throughput)

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,11 @@ Now you're ready to go!
 | `eip-allocation-id` | Optional. Used only with the `start` mode. | Allocation Id of an Elastic IP to associate with the runner instance once it is running. |
 | `runner-version` | Optional. Used only with the `start` mode. | Version of the `actions/runner` binary to download and register (default `2.335.1`). <br><br> Must have a matching entry in `src/runner-checksums.js`; the action verifies the downloaded tarball's SHA-256 against that table before extraction. |
 | `http-tokens` | Optional. Used only with the `start` mode. | Instance Metadata Service (IMDS) token mode (default `required`). <br><br> - `required` — IMDSv2 only; mitigates SSRF-style credential theft. <br> - `optional` — also allows IMDSv1; set only if a workload on the runner needs it. |
-| `encrypt-ebs` | Optional. Used only with the `start` mode. | When `true`, the root EBS volume is created with SSE-EBS encryption using the account's default AWS-managed key (default `false`). Volume size / type / IOPS are preserved from the AMI. |
+| `encrypt-ebs` | Optional. Used only with the `start` mode. | When `true`, the root EBS volume is created with SSE-EBS encryption using the account's default AWS-managed key (default `false`). Volume size / type / IOPS are preserved from the AMI unless overridden by the `volume-*` inputs below. |
+| `volume-size` | Optional. Used only with the `start` mode. | Root EBS volume size in GiB. Omitted = AMI default (Amazon Linux 2023: 8 GiB). Must be ≥ the AMI snapshot size. See [Disk space for Docker workloads](#disk-space-for-docker-workloads). |
+| `volume-type` | Optional. Used only with the `start` mode. | Root EBS volume type: `gp3` (recommended), `gp2`, `io1`, or `io2`. Omitted = AMI default. |
+| `volume-iops` | Optional. Used only with the `start` mode. | Provisioned IOPS for the root volume. Only valid with `volume-type` `io1`, `io2`, or `gp3`. |
+| `volume-throughput` | Optional. Used only with the `start` mode. | Root volume throughput in MiB/s. Only valid with `volume-type` `gp3`. |
 | `cleanup-on-start-failure` | Optional. Used only with the `start` mode. | When `true` (default), a runner that fails to bootstrap or register has its console output captured and is then terminated so the failed start doesn't leak a billing instance. Set `false` to leave the instance running for interactive debugging. <br><br> **Behavior change:** older versions left the instance running after a registration timeout; the default is now to terminate it. See [Troubleshooting a failed start](#troubleshooting-a-failed-start). |
 | `max-lifetime-minutes` | Optional. Used only with the `start` mode. | Hard upper bound (minutes) on the instance's lifetime (default `360`). The instance arms a self-shutdown timer and launches with `InstanceInitiatedShutdownBehavior=terminate`, so it terminates itself at the TTL even if GitHub, the workflow, and AWS APIs are all unreachable. Size it **above your longest legitimate job** — a job still running at the TTL is killed. Set `0` to disable. See [Reaping orphaned runners](#reaping-orphaned-runners-mode-cleanup). |
 | `max-age-minutes` | Optional. Used only with the `cleanup` mode. | A registered-but-idle runner instance older than this many minutes is reaped (default `120`). Instances whose runner is no longer registered are reaped regardless of age, subject to a 15-minute grace floor that protects in-flight starts. Busy runners are never reaped. |
@@ -414,6 +418,23 @@ jobs:
 In [this discussion](https://github.com/machulav/ec2-github-runner/discussions/19), you can find feedback and examples from the users of the action.
 
 If you use this action in your workflow, feel free to add your story there as well 🙌
+
+## Disk space for Docker workloads
+
+The runner inherits the AMI's root volume size — 8 GiB on Amazon Linux 2023. Docker-based CI exhausts that almost immediately (a couple of large images plus build cache), and the job dies with `no space left on device` — one of the most common self-hosted-runner failures. Size the root volume for your workload:
+
+```yml
+- name: Start EC2 runner
+  uses: namecheap/ec2-github-runner@v3
+  with:
+    mode: start
+    # ... other inputs ...
+    volume-size: 100 # GiB
+    volume-type: gp3
+    volume-throughput: 250 # MiB/s (gp3 only, optional)
+```
+
+`volume-size` must be at least the AMI snapshot size (validated up front). The volume is always created with `DeleteOnTermination: true`, so it's removed with the ephemeral instance and never leaks. Sizing composes with `encrypt-ebs` — set both to get an encrypted, resized root volume in one shot.
 
 ## Reaping orphaned runners (`mode: cleanup`)
 

--- a/action.yml
+++ b/action.yml
@@ -94,6 +94,28 @@ inputs:
       this — opt in explicitly when you've verified the permissions.
     required: false
     default: 'false'
+  volume-size:
+    description: >-
+      Used only with the 'start' mode. Root EBS volume size in GiB. When
+      omitted, the AMI's default size is used (Amazon Linux 2023: 8 GiB,
+      which Docker-based CI exhausts quickly). Must be >= the AMI snapshot
+      size. Composes with encrypt-ebs.
+    required: false
+  volume-type:
+    description: >-
+      Used only with the 'start' mode. Root EBS volume type: one of gp3
+      (recommended), gp2, io1, io2. When omitted, the AMI default is used.
+    required: false
+  volume-iops:
+    description: >-
+      Used only with the 'start' mode. Provisioned IOPS for the root
+      volume. Only valid with volume-type io1, io2, or gp3.
+    required: false
+  volume-throughput:
+    description: >-
+      Used only with the 'start' mode. Root volume throughput in MiB/s.
+      Only valid with volume-type gp3.
+    required: false
   http-tokens:
     description: >-
       Instance Metadata Service (IMDS) token mode. Accepted values:

--- a/dist/index.js
+++ b/dist/index.js
@@ -104747,11 +104747,42 @@ async function resolveImage(client) {
   return { id: picked.ImageId, image: picked };
 }
 
-// Build BlockDeviceMappings that encrypt the AMI's root volume without
-// changing its size, type, or iops. Returns null when no root mapping
-// is present on the image (exotic AMIs) — caller should skip encryption
-// and log a warning rather than ship a broken RunInstances call.
-function buildEncryptedRootMapping(image) {
+// True when the launch needs a custom root BlockDeviceMapping — i.e. the
+// user opted into encryption or any root-volume override. When false the
+// caller omits BlockDeviceMappings entirely, so the instance inherits the
+// AMI's block device mapping byte-for-byte (zero-diff vs. the default).
+function wantsRootDeviceMapping(input) {
+  return input.encryptEbs === 'true'
+    || !!input.volumeSize
+    || !!input.volumeType
+    || !!input.volumeIops
+    || !!input.volumeThroughput;
+}
+
+// Normalize the root-volume-related config inputs (strings) into a typed
+// options object for buildRootDeviceMapping. Omitted inputs become
+// undefined so the builder leaves the AMI default untouched.
+function buildVolumeOpts(input) {
+  return {
+    encrypt: input.encryptEbs === 'true',
+    volumeSize: input.volumeSize ? Number(input.volumeSize) : undefined,
+    volumeType: input.volumeType || undefined,
+    volumeIops: input.volumeIops ? Number(input.volumeIops) : undefined,
+    volumeThroughput: input.volumeThroughput ? Number(input.volumeThroughput) : undefined,
+  };
+}
+
+// Build BlockDeviceMappings for the AMI's root volume, composing
+// encryption (encrypt-ebs) and sizing (volume-size/type/iops/throughput)
+// into a single mapping — one writer, not two competing ones. Clones the
+// AMI's root Ebs config, drops SnapshotId (AWS uses the AMI's snapshot
+// automatically), and applies only the requested overrides so omitted
+// inputs keep AMI defaults. DeleteOnTermination is always forced true —
+// ephemeral runners must never leak their root volume. Returns null when
+// the AMI has no root EBS mapping (exotic AMIs); the caller logs a warning
+// rather than shipping a broken RunInstances call. Throws when the
+// requested size is smaller than the AMI snapshot (invalid, fail fast).
+function buildRootDeviceMapping(image, opts = {}) {
   const rootDev = image.RootDeviceName;
   if (!rootDev || !Array.isArray(image.BlockDeviceMappings)) {
     return null;
@@ -104760,15 +104791,35 @@ function buildEncryptedRootMapping(image) {
   if (!rootMap || !rootMap.Ebs) {
     return null;
   }
-  // Clone the EBS config and set Encrypted: true. Drop SnapshotId — AWS
-  // will use the AMI's snapshot automatically and re-encrypt during
-  // launch under the account's default EBS key.
-  const ebsClone = { ...rootMap.Ebs };
-  delete ebsClone.SnapshotId;
-  return [{
-    DeviceName: rootDev,
-    Ebs: { ...ebsClone, Encrypted: true },
-  }];
+
+  const ebs = { ...rootMap.Ebs };
+  const snapshotSize = ebs.VolumeSize;
+  delete ebs.SnapshotId;
+  ebs.DeleteOnTermination = true;
+
+  if (opts.encrypt) {
+    ebs.Encrypted = true;
+  }
+  if (opts.volumeSize != null) {
+    if (snapshotSize != null && opts.volumeSize < snapshotSize) {
+      throw new Error(
+        `volume-size ${opts.volumeSize} GiB is smaller than the AMI snapshot size ${snapshotSize} GiB; ` +
+        'an EBS volume cannot be smaller than the snapshot it is created from.',
+      );
+    }
+    ebs.VolumeSize = opts.volumeSize;
+  }
+  if (opts.volumeType) {
+    ebs.VolumeType = opts.volumeType;
+  }
+  if (opts.volumeIops != null) {
+    ebs.Iops = opts.volumeIops;
+  }
+  if (opts.volumeThroughput != null) {
+    ebs.Throughput = opts.volumeThroughput;
+  }
+
+  return [{ DeviceName: rootDev, Ebs: ebs }];
 }
 
 // Build the cloud-init user-data bootstrap script.
@@ -104985,15 +105036,21 @@ async function startEc2Instance(label, githubRegistrationToken) {
     params.InstanceInitiatedShutdownBehavior = 'terminate';
   }
 
-  if (config.input.encryptEbs === 'true') {
-    const mappings = buildEncryptedRootMapping(resolved.image);
+  if (wantsRootDeviceMapping(config.input)) {
+    const mappings = buildRootDeviceMapping(resolved.image, buildVolumeOpts(config.input));
     if (mappings) {
       params.BlockDeviceMappings = mappings;
-      log.info('encrypt_ebs', { applied: true, root_device: mappings[0].DeviceName });
+      log.info('root_volume', {
+        applied: true,
+        root_device: mappings[0].DeviceName,
+        encrypted: mappings[0].Ebs.Encrypted === true,
+        volume_size: mappings[0].Ebs.VolumeSize,
+        volume_type: mappings[0].Ebs.VolumeType,
+      });
     } else {
-      log.warn('encrypt_ebs', {
+      log.warn('root_volume', {
         applied: false,
-        reason: 'ami has no root EBS block-device mapping — skipping encryption override',
+        reason: 'ami has no root EBS block-device mapping — skipping encryption/sizing override',
         ami_id: resolved.id,
       });
     }
@@ -105212,7 +105269,9 @@ module.exports = {
   handleStartFailure,
   listManagedInstances,
   // Exported for unit testing.
-  buildEncryptedRootMapping,
+  buildRootDeviceMapping,
+  wantsRootDeviceMapping,
+  buildVolumeOpts,
   buildUserData,
   buildTagSpecifications,
   redactSecrets,
@@ -105393,6 +105452,10 @@ class Config {
       runnerVersion: core.getInput('runner-version') || '2.335.1',
       httpTokens: core.getInput('http-tokens') || 'required',
       encryptEbs: core.getInput('encrypt-ebs') || 'false',
+      volumeSize: core.getInput('volume-size'),
+      volumeType: core.getInput('volume-type'),
+      volumeIops: core.getInput('volume-iops'),
+      volumeThroughput: core.getInput('volume-throughput'),
       cleanupOnStartFailure: core.getInput('cleanup-on-start-failure') || 'true',
       maxLifetimeMinutes: core.getInput('max-lifetime-minutes') || '360',
       maxAgeMinutes: core.getInput('max-age-minutes') || '120',
@@ -105433,6 +105496,7 @@ class Config {
       if (!this.input.ec2ImageId && !this.input.ec2ImageFilters) {
         throw new Error(`Not all the required inputs for AMI search are provided for the 'start' mode`);
       }
+      this.validateVolumeInputs();
     } else if (this.input.mode === 'stop') {
       if (!this.input.label || !this.input.ec2InstanceId) {
         throw new Error(`Not all the required inputs are provided for the 'stop' mode`);
@@ -105443,6 +105507,35 @@ class Config {
       // have safe defaults.
     } else {
       throw new Error('Wrong mode. Allowed values: start, stop, cleanup.');
+    }
+  }
+
+  // Validate the root-volume inputs against EBS rules that don't need the
+  // AMI (fail in seconds at config parse). The size-vs-snapshot check needs
+  // the DescribeImages data and lives in src/aws.js buildRootDeviceMapping.
+  validateVolumeInputs() {
+    const { volumeSize, volumeType, volumeIops, volumeThroughput } = this.input;
+    const ALLOWED_TYPES = ['gp3', 'gp2', 'io1', 'io2'];
+    const IOPS_TYPES = ['gp3', 'io1', 'io2'];
+    const isPositiveInt = (v) => /^[0-9]+$/.test(v) && Number(v) > 0;
+
+    if (volumeSize && !isPositiveInt(volumeSize)) {
+      throw new Error(`'volume-size' must be a positive integer (GiB)`);
+    }
+    if (volumeIops && !isPositiveInt(volumeIops)) {
+      throw new Error(`'volume-iops' must be a positive integer`);
+    }
+    if (volumeThroughput && !isPositiveInt(volumeThroughput)) {
+      throw new Error(`'volume-throughput' must be a positive integer (MiB/s)`);
+    }
+    if (volumeType && !ALLOWED_TYPES.includes(volumeType)) {
+      throw new Error(`'volume-type' must be one of: ${ALLOWED_TYPES.join(', ')}`);
+    }
+    if (volumeIops && !IOPS_TYPES.includes(volumeType)) {
+      throw new Error(`'volume-iops' is only valid with 'volume-type' one of: ${IOPS_TYPES.join(', ')}`);
+    }
+    if (volumeThroughput && volumeType !== 'gp3') {
+      throw new Error(`'volume-throughput' is only valid with 'volume-type' gp3`);
     }
   }
 

--- a/src/aws.js
+++ b/src/aws.js
@@ -97,11 +97,42 @@ async function resolveImage(client) {
   return { id: picked.ImageId, image: picked };
 }
 
-// Build BlockDeviceMappings that encrypt the AMI's root volume without
-// changing its size, type, or iops. Returns null when no root mapping
-// is present on the image (exotic AMIs) — caller should skip encryption
-// and log a warning rather than ship a broken RunInstances call.
-function buildEncryptedRootMapping(image) {
+// True when the launch needs a custom root BlockDeviceMapping — i.e. the
+// user opted into encryption or any root-volume override. When false the
+// caller omits BlockDeviceMappings entirely, so the instance inherits the
+// AMI's block device mapping byte-for-byte (zero-diff vs. the default).
+function wantsRootDeviceMapping(input) {
+  return input.encryptEbs === 'true'
+    || !!input.volumeSize
+    || !!input.volumeType
+    || !!input.volumeIops
+    || !!input.volumeThroughput;
+}
+
+// Normalize the root-volume-related config inputs (strings) into a typed
+// options object for buildRootDeviceMapping. Omitted inputs become
+// undefined so the builder leaves the AMI default untouched.
+function buildVolumeOpts(input) {
+  return {
+    encrypt: input.encryptEbs === 'true',
+    volumeSize: input.volumeSize ? Number(input.volumeSize) : undefined,
+    volumeType: input.volumeType || undefined,
+    volumeIops: input.volumeIops ? Number(input.volumeIops) : undefined,
+    volumeThroughput: input.volumeThroughput ? Number(input.volumeThroughput) : undefined,
+  };
+}
+
+// Build BlockDeviceMappings for the AMI's root volume, composing
+// encryption (encrypt-ebs) and sizing (volume-size/type/iops/throughput)
+// into a single mapping — one writer, not two competing ones. Clones the
+// AMI's root Ebs config, drops SnapshotId (AWS uses the AMI's snapshot
+// automatically), and applies only the requested overrides so omitted
+// inputs keep AMI defaults. DeleteOnTermination is always forced true —
+// ephemeral runners must never leak their root volume. Returns null when
+// the AMI has no root EBS mapping (exotic AMIs); the caller logs a warning
+// rather than shipping a broken RunInstances call. Throws when the
+// requested size is smaller than the AMI snapshot (invalid, fail fast).
+function buildRootDeviceMapping(image, opts = {}) {
   const rootDev = image.RootDeviceName;
   if (!rootDev || !Array.isArray(image.BlockDeviceMappings)) {
     return null;
@@ -110,15 +141,35 @@ function buildEncryptedRootMapping(image) {
   if (!rootMap || !rootMap.Ebs) {
     return null;
   }
-  // Clone the EBS config and set Encrypted: true. Drop SnapshotId — AWS
-  // will use the AMI's snapshot automatically and re-encrypt during
-  // launch under the account's default EBS key.
-  const ebsClone = { ...rootMap.Ebs };
-  delete ebsClone.SnapshotId;
-  return [{
-    DeviceName: rootDev,
-    Ebs: { ...ebsClone, Encrypted: true },
-  }];
+
+  const ebs = { ...rootMap.Ebs };
+  const snapshotSize = ebs.VolumeSize;
+  delete ebs.SnapshotId;
+  ebs.DeleteOnTermination = true;
+
+  if (opts.encrypt) {
+    ebs.Encrypted = true;
+  }
+  if (opts.volumeSize != null) {
+    if (snapshotSize != null && opts.volumeSize < snapshotSize) {
+      throw new Error(
+        `volume-size ${opts.volumeSize} GiB is smaller than the AMI snapshot size ${snapshotSize} GiB; ` +
+        'an EBS volume cannot be smaller than the snapshot it is created from.',
+      );
+    }
+    ebs.VolumeSize = opts.volumeSize;
+  }
+  if (opts.volumeType) {
+    ebs.VolumeType = opts.volumeType;
+  }
+  if (opts.volumeIops != null) {
+    ebs.Iops = opts.volumeIops;
+  }
+  if (opts.volumeThroughput != null) {
+    ebs.Throughput = opts.volumeThroughput;
+  }
+
+  return [{ DeviceName: rootDev, Ebs: ebs }];
 }
 
 // Build the cloud-init user-data bootstrap script.
@@ -335,15 +386,21 @@ async function startEc2Instance(label, githubRegistrationToken) {
     params.InstanceInitiatedShutdownBehavior = 'terminate';
   }
 
-  if (config.input.encryptEbs === 'true') {
-    const mappings = buildEncryptedRootMapping(resolved.image);
+  if (wantsRootDeviceMapping(config.input)) {
+    const mappings = buildRootDeviceMapping(resolved.image, buildVolumeOpts(config.input));
     if (mappings) {
       params.BlockDeviceMappings = mappings;
-      log.info('encrypt_ebs', { applied: true, root_device: mappings[0].DeviceName });
+      log.info('root_volume', {
+        applied: true,
+        root_device: mappings[0].DeviceName,
+        encrypted: mappings[0].Ebs.Encrypted === true,
+        volume_size: mappings[0].Ebs.VolumeSize,
+        volume_type: mappings[0].Ebs.VolumeType,
+      });
     } else {
-      log.warn('encrypt_ebs', {
+      log.warn('root_volume', {
         applied: false,
-        reason: 'ami has no root EBS block-device mapping — skipping encryption override',
+        reason: 'ami has no root EBS block-device mapping — skipping encryption/sizing override',
         ami_id: resolved.id,
       });
     }
@@ -562,7 +619,9 @@ module.exports = {
   handleStartFailure,
   listManagedInstances,
   // Exported for unit testing.
-  buildEncryptedRootMapping,
+  buildRootDeviceMapping,
+  wantsRootDeviceMapping,
+  buildVolumeOpts,
   buildUserData,
   buildTagSpecifications,
   redactSecrets,

--- a/src/config.js
+++ b/src/config.js
@@ -19,6 +19,10 @@ class Config {
       runnerVersion: core.getInput('runner-version') || '2.335.1',
       httpTokens: core.getInput('http-tokens') || 'required',
       encryptEbs: core.getInput('encrypt-ebs') || 'false',
+      volumeSize: core.getInput('volume-size'),
+      volumeType: core.getInput('volume-type'),
+      volumeIops: core.getInput('volume-iops'),
+      volumeThroughput: core.getInput('volume-throughput'),
       cleanupOnStartFailure: core.getInput('cleanup-on-start-failure') || 'true',
       maxLifetimeMinutes: core.getInput('max-lifetime-minutes') || '360',
       maxAgeMinutes: core.getInput('max-age-minutes') || '120',
@@ -59,6 +63,7 @@ class Config {
       if (!this.input.ec2ImageId && !this.input.ec2ImageFilters) {
         throw new Error(`Not all the required inputs for AMI search are provided for the 'start' mode`);
       }
+      this.validateVolumeInputs();
     } else if (this.input.mode === 'stop') {
       if (!this.input.label || !this.input.ec2InstanceId) {
         throw new Error(`Not all the required inputs are provided for the 'stop' mode`);
@@ -69,6 +74,35 @@ class Config {
       // have safe defaults.
     } else {
       throw new Error('Wrong mode. Allowed values: start, stop, cleanup.');
+    }
+  }
+
+  // Validate the root-volume inputs against EBS rules that don't need the
+  // AMI (fail in seconds at config parse). The size-vs-snapshot check needs
+  // the DescribeImages data and lives in src/aws.js buildRootDeviceMapping.
+  validateVolumeInputs() {
+    const { volumeSize, volumeType, volumeIops, volumeThroughput } = this.input;
+    const ALLOWED_TYPES = ['gp3', 'gp2', 'io1', 'io2'];
+    const IOPS_TYPES = ['gp3', 'io1', 'io2'];
+    const isPositiveInt = (v) => /^[0-9]+$/.test(v) && Number(v) > 0;
+
+    if (volumeSize && !isPositiveInt(volumeSize)) {
+      throw new Error(`'volume-size' must be a positive integer (GiB)`);
+    }
+    if (volumeIops && !isPositiveInt(volumeIops)) {
+      throw new Error(`'volume-iops' must be a positive integer`);
+    }
+    if (volumeThroughput && !isPositiveInt(volumeThroughput)) {
+      throw new Error(`'volume-throughput' must be a positive integer (MiB/s)`);
+    }
+    if (volumeType && !ALLOWED_TYPES.includes(volumeType)) {
+      throw new Error(`'volume-type' must be one of: ${ALLOWED_TYPES.join(', ')}`);
+    }
+    if (volumeIops && !IOPS_TYPES.includes(volumeType)) {
+      throw new Error(`'volume-iops' is only valid with 'volume-type' one of: ${IOPS_TYPES.join(', ')}`);
+    }
+    if (volumeThroughput && volumeType !== 'gp3') {
+      throw new Error(`'volume-throughput' is only valid with 'volume-type' gp3`);
     }
   }
 

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -152,6 +152,46 @@ describe('Config — cleanup mode', () => {
   });
 });
 
+describe('Config — root volume inputs', () => {
+  test('accepts a valid gp3 sizing combination', () => {
+    const config = loadConfig({ ...startModeInputs, 'volume-size': '100', 'volume-type': 'gp3', 'volume-iops': '4000', 'volume-throughput': '250' });
+    expect(config.input.volumeSize).toBe('100');
+    expect(config.input.volumeType).toBe('gp3');
+    expect(config.input.volumeIops).toBe('4000');
+    expect(config.input.volumeThroughput).toBe('250');
+  });
+
+  test('no volume inputs is valid (AMI defaults)', () => {
+    const config = loadConfig(startModeInputs);
+    expect(config.input.volumeSize).toBe('');
+  });
+
+  test('rejects a non-numeric volume-size', () => {
+    expectValidationFailure({ ...startModeInputs, 'volume-size': 'big' }, /'volume-size' must be a positive integer/);
+  });
+
+  test('rejects a zero / negative volume-size', () => {
+    expectValidationFailure({ ...startModeInputs, 'volume-size': '0' }, /'volume-size' must be a positive integer/);
+  });
+
+  test('rejects an unknown volume-type', () => {
+    expectValidationFailure({ ...startModeInputs, 'volume-type': 'gp4' }, /'volume-type' must be one of/);
+  });
+
+  test('rejects volume-iops with an incompatible type', () => {
+    expectValidationFailure({ ...startModeInputs, 'volume-type': 'gp2', 'volume-iops': '4000' }, /'volume-iops' is only valid/);
+  });
+
+  test('rejects volume-throughput with a non-gp3 type', () => {
+    expectValidationFailure({ ...startModeInputs, 'volume-type': 'io2', 'volume-iops': '4000', 'volume-throughput': '250' }, /'volume-throughput' is only valid with 'volume-type' gp3/);
+  });
+
+  test('accepts iops with io2', () => {
+    const config = loadConfig({ ...startModeInputs, 'volume-type': 'io2', 'volume-iops': '5000' });
+    expect(config.input.volumeIops).toBe('5000');
+  });
+});
+
 describe('Config — max-lifetime-minutes input', () => {
   test('defaults to 360 when unset', () => {
     const config = loadConfig(startModeInputs);

--- a/tests/ebs.test.js
+++ b/tests/ebs.test.js
@@ -1,94 +1,125 @@
-// Tests for buildEncryptedRootMapping. The function is a pure transform
-// of a DescribeImages response — no AWS/GitHub stubbing required.
-//
-// aws.js and config.js are required at module load time, so mocks must be
-// in place before any require() runs. jest.mock() is hoisted by Jest's
-// transform and executes before module-level require() calls.
+// Tests for the root-device mapping builder and its helpers. Pure
+// transforms of a DescribeImages response — no AWS/GitHub stubbing needed.
+// jest.mock is hoisted and runs before the module-level require()s.
 jest.mock('../src/config', () => ({
   input: { mode: 'start', debug: 'false' },
   githubContext: { owner: 'o', repo: 'r' },
-  tagSpecifications: null,
 }));
 jest.mock('@actions/core', () => ({
   info: jest.fn(), warning: jest.fn(), error: jest.fn(), setFailed: jest.fn(), getInput: jest.fn(),
   startGroup: jest.fn(), endGroup: jest.fn(),
 }));
 
-const { buildEncryptedRootMapping } = require('../src/aws');
+const { buildRootDeviceMapping, wantsRootDeviceMapping, buildVolumeOpts } = require('../src/aws');
 
-describe('buildEncryptedRootMapping', () => {
+const imageWith = (ebs, rootDev = '/dev/xvda') => ({
+  RootDeviceName: rootDev,
+  BlockDeviceMappings: [
+    { DeviceName: rootDev, Ebs: ebs },
+    { DeviceName: '/dev/sdb', VirtualName: 'ephemeral0' },
+  ],
+});
+
+describe('buildRootDeviceMapping — encryption', () => {
   test('clones the AMI root mapping and flips Encrypted to true', () => {
-    const image = {
-      RootDeviceName: '/dev/xvda',
-      BlockDeviceMappings: [
-        {
-          DeviceName: '/dev/xvda',
-          Ebs: {
-            SnapshotId: 'snap-abc',
-            VolumeSize: 30,
-            VolumeType: 'gp3',
-            Iops: 3000,
-            DeleteOnTermination: true,
-          },
-        },
-        { DeviceName: '/dev/sdb', VirtualName: 'ephemeral0' }, // non-EBS, should be ignored
-      ],
-    };
-
-    const result = buildEncryptedRootMapping(image);
-
+    const image = imageWith({ SnapshotId: 'snap-abc', VolumeSize: 30, VolumeType: 'gp3', Iops: 3000, DeleteOnTermination: true });
+    const result = buildRootDeviceMapping(image, { encrypt: true });
     expect(result).toEqual([{
       DeviceName: '/dev/xvda',
-      Ebs: {
-        VolumeSize: 30,
-        VolumeType: 'gp3',
-        Iops: 3000,
-        DeleteOnTermination: true,
-        Encrypted: true,
-      },
+      Ebs: { VolumeSize: 30, VolumeType: 'gp3', Iops: 3000, DeleteOnTermination: true, Encrypted: true },
     }]);
-    // SnapshotId must be dropped (AWS uses the AMI's snapshot automatically).
     expect(result[0].Ebs.SnapshotId).toBeUndefined();
   });
 
-  test('preserves volume type + size + IOPS untouched', () => {
-    const image = {
-      RootDeviceName: '/dev/sda1',
-      BlockDeviceMappings: [{
-        DeviceName: '/dev/sda1',
-        Ebs: { VolumeSize: 100, VolumeType: 'io2', Iops: 10000 },
-      }],
-    };
+  test('does not set Encrypted when encrypt is false', () => {
+    const result = buildRootDeviceMapping(imageWith({ VolumeSize: 30 }), { volumeSize: 50 });
+    expect(result[0].Ebs.Encrypted).toBeUndefined();
+  });
+});
 
-    const result = buildEncryptedRootMapping(image);
-
-    expect(result[0].Ebs.VolumeSize).toBe(100);
-    expect(result[0].Ebs.VolumeType).toBe('io2');
-    expect(result[0].Ebs.Iops).toBe(10000);
-    expect(result[0].Ebs.Encrypted).toBe(true);
+describe('buildRootDeviceMapping — sizing', () => {
+  test('applies size / type / iops / throughput overrides', () => {
+    const image = imageWith({ VolumeSize: 8, VolumeType: 'gp3' });
+    const result = buildRootDeviceMapping(image, { volumeSize: 100, volumeType: 'gp3', volumeIops: 4000, volumeThroughput: 250 });
+    expect(result[0].Ebs).toMatchObject({ VolumeSize: 100, VolumeType: 'gp3', Iops: 4000, Throughput: 250 });
   });
 
+  test('leaves omitted fields at the AMI default', () => {
+    const image = imageWith({ VolumeSize: 30, VolumeType: 'gp2' });
+    const result = buildRootDeviceMapping(image, { volumeSize: 60 });
+    expect(result[0].Ebs.VolumeSize).toBe(60);
+    expect(result[0].Ebs.VolumeType).toBe('gp2'); // untouched
+  });
+
+  test('composes encryption AND sizing in a single mapping', () => {
+    const image = imageWith({ VolumeSize: 8, VolumeType: 'gp3' });
+    const result = buildRootDeviceMapping(image, { encrypt: true, volumeSize: 120, volumeType: 'gp3', volumeThroughput: 300 });
+    expect(result).toHaveLength(1);
+    expect(result[0].Ebs).toMatchObject({ Encrypted: true, VolumeSize: 120, VolumeType: 'gp3', Throughput: 300, DeleteOnTermination: true });
+  });
+
+  test('rejects a size smaller than the AMI snapshot, naming both numbers', () => {
+    const image = imageWith({ VolumeSize: 30 });
+    expect(() => buildRootDeviceMapping(image, { volumeSize: 20 })).toThrow(/20 GiB.*30 GiB/);
+  });
+
+  test('allows a size equal to the AMI snapshot', () => {
+    const image = imageWith({ VolumeSize: 30 });
+    expect(buildRootDeviceMapping(image, { volumeSize: 30 })[0].Ebs.VolumeSize).toBe(30);
+  });
+});
+
+describe('buildRootDeviceMapping — DeleteOnTermination', () => {
+  test('is always forced true, even when the AMI omits it', () => {
+    expect(buildRootDeviceMapping(imageWith({ VolumeSize: 8 }), { encrypt: true })[0].Ebs.DeleteOnTermination).toBe(true);
+    expect(buildRootDeviceMapping(imageWith({ VolumeSize: 8 }), { volumeSize: 50 })[0].Ebs.DeleteOnTermination).toBe(true);
+  });
+
+  test('overrides an AMI mapping that set DeleteOnTermination false', () => {
+    const image = imageWith({ VolumeSize: 8, DeleteOnTermination: false });
+    expect(buildRootDeviceMapping(image, { volumeSize: 50 })[0].Ebs.DeleteOnTermination).toBe(true);
+  });
+});
+
+describe('buildRootDeviceMapping — null cases', () => {
   test('returns null when the AMI has no root device name', () => {
-    expect(buildEncryptedRootMapping({ BlockDeviceMappings: [] })).toBeNull();
+    expect(buildRootDeviceMapping({ BlockDeviceMappings: [] }, { encrypt: true })).toBeNull();
   });
-
   test('returns null when the AMI has no BlockDeviceMappings', () => {
-    expect(buildEncryptedRootMapping({ RootDeviceName: '/dev/xvda' })).toBeNull();
+    expect(buildRootDeviceMapping({ RootDeviceName: '/dev/xvda' }, { encrypt: true })).toBeNull();
   });
-
   test('returns null when the root mapping has no Ebs sub-object', () => {
-    const image = {
-      RootDeviceName: '/dev/xvda',
-      BlockDeviceMappings: [{ DeviceName: '/dev/xvda', VirtualName: 'ephemeral0' }],
-    };
-    expect(buildEncryptedRootMapping(image)).toBeNull();
+    const image = { RootDeviceName: '/dev/xvda', BlockDeviceMappings: [{ DeviceName: '/dev/xvda', VirtualName: 'ephemeral0' }] };
+    expect(buildRootDeviceMapping(image, { encrypt: true })).toBeNull();
   });
+  test('returns null when RootDeviceName points to a missing mapping', () => {
+    const image = { RootDeviceName: '/dev/xvda', BlockDeviceMappings: [{ DeviceName: '/dev/sdb', Ebs: { VolumeSize: 10 } }] };
+    expect(buildRootDeviceMapping(image, { encrypt: true })).toBeNull();
+  });
+});
 
-  test('returns null when RootDeviceName points to a mapping that doesn\'t exist', () => {
-    const image = {
-      RootDeviceName: '/dev/xvda',
-      BlockDeviceMappings: [{ DeviceName: '/dev/sdb', Ebs: { VolumeSize: 10 } }],
-    };
-    expect(buildEncryptedRootMapping(image)).toBeNull();
+describe('wantsRootDeviceMapping — zero-diff regression', () => {
+  test('false when no encryption and no volume inputs (AMI default preserved)', () => {
+    expect(wantsRootDeviceMapping({ encryptEbs: 'false', volumeSize: '', volumeType: '', volumeIops: '', volumeThroughput: '' })).toBe(false);
+  });
+  test('true when encryption is on', () => {
+    expect(wantsRootDeviceMapping({ encryptEbs: 'true' })).toBe(true);
+  });
+  test('true when any single volume input is set', () => {
+    expect(wantsRootDeviceMapping({ encryptEbs: 'false', volumeSize: '100' })).toBe(true);
+    expect(wantsRootDeviceMapping({ encryptEbs: 'false', volumeType: 'gp3' })).toBe(true);
+    expect(wantsRootDeviceMapping({ encryptEbs: 'false', volumeIops: '4000' })).toBe(true);
+    expect(wantsRootDeviceMapping({ encryptEbs: 'false', volumeThroughput: '250' })).toBe(true);
+  });
+});
+
+describe('buildVolumeOpts', () => {
+  test('parses numeric inputs and leaves omitted ones undefined', () => {
+    const opts = buildVolumeOpts({ encryptEbs: 'true', volumeSize: '100', volumeType: 'gp3', volumeIops: '4000', volumeThroughput: '250' });
+    expect(opts).toEqual({ encrypt: true, volumeSize: 100, volumeType: 'gp3', volumeIops: 4000, volumeThroughput: 250 });
+  });
+  test('undefined for unset numeric fields, encrypt false when not "true"', () => {
+    const opts = buildVolumeOpts({ encryptEbs: 'false', volumeSize: '', volumeType: '', volumeIops: '', volumeThroughput: '' });
+    expect(opts).toEqual({ encrypt: false, volumeSize: undefined, volumeType: undefined, volumeIops: undefined, volumeThroughput: undefined });
   });
 });


### PR DESCRIPTION
Closes #44 — roadmap (#49); small, self-contained, high frequency-of-pain.

## Problem
No control over the root volume — instances inherit the AMI mapping (AL2023: 8 GiB gp3). Docker CI exhausts that instantly → `no space left on device`, one of the most common self-hosted-runner failures.

## New inputs (start mode)
```yaml
volume-size: 100        # GiB, >= AMI snapshot size
volume-type: gp3        # gp3 (recommended) | gp2 | io1 | io2
volume-iops: 4000       # io1/io2/gp3 only
volume-throughput: 250  # gp3 only (MiB/s)
```

## Design
- **One writer, not two**: unified `buildRootDeviceMapping` composes encryption (`encrypt-ebs`) **and** sizing into a single root mapping — replaces the encryption-only `buildEncryptedRootMapping`.
- **No leaks**: `DeleteOnTermination: true` is always forced (explicitly asserted), even if the AMI set it false.
- **Fail fast**: type/iops/throughput combos validated at config parse (iops → io1/io2/gp3; throughput → gp3 only); size-below-AMI-snapshot rejected with both numbers, using the DescribeImages data already fetched for encryption.
- **Zero-diff default**: with no encryption and no volume inputs, no `BlockDeviceMappings` is emitted at all — AMI default preserved byte-for-byte (covered by `wantsRootDeviceMapping` regression tests).

## Tests / build
- `tests/ebs.test.js` rewritten for the unified builder (encryption, sizing, compose, DeleteOnTermination, null cases, size-below-snapshot), plus config combo-validation and opt-parsing tests. **128 tests pass** (was 108). Lint clean, dist rebuilt (verify-dist green).

## Docs
- README: "Disk space for Docker workloads" note with a recommended gp3 example + inputs-table rows; action.yml descriptions.

## Compatibility
- Existing inputs unchanged; `encrypt-ebs`-only behavior is byte-identical apart from `DeleteOnTermination` now being explicit (previously inherited from the AMI, normally already true).