### PR TITLE
fix: correct sed delimiter in GH_REPO_URL extraction (#63)

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -105018,7 +105018,7 @@ function buildReusableUserData({ runnerVersion, owner, repo, label, githubRegist
     'UD=$(curl -fsS -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" "http://169.254.169.254/latest/user-data" 2>/dev/null || true)',
     'GH_TOKEN=$(printf \'%s\\n\' "$UD" | sed -n "s/^GH_TOKEN=\'\\(.*\\)\'$/\\1/p" | head -n1)',
     'GH_LABEL=$(printf \'%s\\n\' "$UD" | sed -n "s/^GH_LABEL=\'\\(.*\\)\'$/\\1/p" | head -n1)',
-    'GH_REPO_URL=$(printf \'%s\\n\' "$UD" | sed -n "s#^GH_REPO_URL=\'\\(.*\\)\'$#\\1#p" | head -n1)',
+    'GH_REPO_URL=$(printf \'%s\\n\' "$UD" | sed -n "s,^GH_REPO_URL=\'\\(.*\\)\'$,\\1,p" | head -n1)',
     'cd /home/runner/actions-runner',
     'rm -f .runner .credentials .credentials_rsaparams',
     'gh_runner_phone_home configuring',

--- a/src/aws.js
+++ b/src/aws.js
@@ -368,7 +368,7 @@ function buildReusableUserData({ runnerVersion, owner, repo, label, githubRegist
     'UD=$(curl -fsS -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" "http://169.254.169.254/latest/user-data" 2>/dev/null || true)',
     'GH_TOKEN=$(printf \'%s\\n\' "$UD" | sed -n "s/^GH_TOKEN=\'\\(.*\\)\'$/\\1/p" | head -n1)',
     'GH_LABEL=$(printf \'%s\\n\' "$UD" | sed -n "s/^GH_LABEL=\'\\(.*\\)\'$/\\1/p" | head -n1)',
-    'GH_REPO_URL=$(printf \'%s\\n\' "$UD" | sed -n "s#^GH_REPO_URL=\'\\(.*\\)\'$#\\1#p" | head -n1)',
+    'GH_REPO_URL=$(printf \'%s\\n\' "$UD" | sed -n "s,^GH_REPO_URL=\'\\(.*\\)\'$,\\1,p" | head -n1)',
     'cd /home/runner/actions-runner',
     'rm -f .runner .credentials .credentials_rsaparams',
     'gh_runner_phone_home configuring',

--- a/tests/warmpool.test.js
+++ b/tests/warmpool.test.js
@@ -1,6 +1,8 @@
 // Tests for warm-pool (reuse: stop) support: findStoppedPoolInstance strict
 // matching, warmStartInstance ordering, stop/cycle helpers, and the per-boot
 // re-registration hook in the generated user-data.
+const { execFileSync } = require('child_process');
+
 const mockSend = jest.fn();
 jest.mock('@aws-sdk/client-ec2', () => ({
   EC2Client: jest.fn(() => ({ send: mockSend })),
@@ -184,5 +186,36 @@ describe('buildUserData — reuse: stop variant', () => {
     const ud = aws.buildUserData({ ...args, reuse: 'terminate' });
     expect(ud).not.toContain('gh-runner.service');
     expect(ud).not.toContain('/opt/gh-runner-register.sh');
+  });
+
+  test('GH_REPO_URL extraction survives the sed-delimiter/$# collision (regression, #63)', () => {
+    const ud = aws.buildUserData({ ...args, reuse: 'stop' });
+
+    // Pull the real GH_REPO_URL=$(... sed ...) line straight out of the
+    // generated script, so this test exercises the actual shipped code
+    // rather than a hand-reimplementation of it.
+    const marker = 'GH_REPO_URL=$(printf';
+    const start = ud.indexOf(marker);
+    expect(start).toBeGreaterThan(-1);
+    const end = ud.indexOf('\n', start);
+    expect(end).toBeGreaterThan(start);
+    const extractionLine = ud.slice(start, end);
+
+    // Run that exact line under 'set -euo pipefail' with a controlled IMDS
+    // user-data value, the same shape the real registerScript reads via
+    // `UD=$(curl ... /latest/user-data)`. If the sed delimiter collides with
+    // bash's `$#` special parameter (as `#` does), the sed invocation is
+    // malformed, the pipeline fails, and the assignment aborts the script
+    // under `set -e` before GH_REPO_URL is ever printed.
+    const script = [
+      '#!/bin/bash',
+      'set -euo pipefail',
+      "UD=\"GH_REPO_URL='https://github.com/foo/bar'\"",
+      extractionLine,
+      'printf \'%s\' "$GH_REPO_URL"',
+    ].join('\n');
+
+    const result = execFileSync('bash', ['-c', script]).toString();
+    expect(result).toBe('https://github.com/foo/bar');
   });
 });


### PR DESCRIPTION
## Summary

Fixes #63.

`buildReusableUserData()`'s per-boot `registerScript` extracted `GH_REPO_URL` with `sed` using `#` as the delimiter, while the `GH_TOKEN` and `GH_LABEL` extraction lines directly above it correctly use `/`. Because the sed pattern ends in the end-of-line anchor `$` immediately followed by the `#` delimiter, and the whole sed argument sits inside a **double-quoted** shell string, bash expands `$#` (the special "number of positional arguments" parameter, always `0` for this script) *before* sed ever sees it. That corrupts the sed script into `s#^GH_REPO_URL='\(.*\)'0\1#p`, which errors with `unterminated 's' command`.

Since this is a plain `GH_REPO_URL=$(...)` assignment under `set -euo pipefail` (no `|| true` guard), the sed failure aborts the whole `registerScript` at the `configuring` phone-home step — before `config.sh` is ever invoked. This is a 100% reproducible failure for every `reuse: stop` warm-pool launch.

## Fix

Swap the delimiter to `,`, which isn't a bash special-parameter suffix when preceded by `$`:

```diff
-'GH_REPO_URL=$(printf \'%s\\n\' "$UD" | sed -n "s#^GH_REPO_URL=\'\\(.*\\)\'$#\\1#p" | head -n1)',
+'GH_REPO_URL=$(printf \'%s\\n\' "$UD" | sed -n "s,^GH_REPO_URL=\'\\(.*\\)\'$,\\1,p" | head -n1)',
```

Verified against both BSD sed (macOS) and GNU sed semantics — this mirrors the exact root cause and fix from the issue writeup.

## Test plan

- [x] Added a regression test in `tests/warmpool.test.js` that extracts the actual `GH_REPO_URL=$(... sed ...)` line out of the real generated user-data (not a reimplementation) and executes it in `bash` with a controlled fake IMDS user-data value.
- [x] Verified the new test **fails** against the old `#`-delimiter line (`sed: unescaped newline inside substitute pattern`, command exits non-zero under `set -e`).
- [x] Verified the new test **passes** against the fix (extracts `https://github.com/foo/bar` correctly).
- [x] Full suite: `npm test` — 227/227 passing (226 pre-existing + 1 new).
- [x] `npm run lint` — clean.
- [x] `npm run package` — rebuilt `dist/index.js`; confirmed the rebuild is deterministic (byte-identical across two consecutive runs) and the diff is scoped to the single fixed line.