### PR TITLE
fix: pass raw user-data bytes to ModifyInstanceAttribute on warm start

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -105809,7 +105809,18 @@ async function warmStartInstance(instanceId, { userData, label }) {
   const client = ec2Client();
   await client.send(new ModifyInstanceAttributeCommand({
     InstanceId: instanceId,
-    UserData: { Value: Buffer.from(userData).toString('base64') },
+    // ModifyInstanceAttribute's UserData is a BLOB (BlobAttributeValue.Value:
+    // Uint8Array), NOT the plain string RunInstances takes. The SDK
+    // base64-encodes the blob's bytes for the EC2 query wire, so hand it the
+    // RAW user-data bytes. Pre-encoding to a base64 STRING here double-encodes
+    // it: the wire carries base64(base64(userData)), EC2 decodes that once and
+    // IMDS then serves the base64 TEXT instead of the script. The warm-restart
+    // register step reads that via IMDS, its `sed` finds no GH_REPO_URL='...'
+    // line, and config.sh aborts with "Invalid configuration provided for url"
+    // — every reuse: stop warm start failed registration this way. Cold
+    // launches were unaffected: RunInstances (startEc2Instance) correctly
+    // pre-encodes because its UserData field is a string, not a blob.
+    UserData: { Value: Buffer.from(userData) },
   }));
   await client.send(new CreateTagsCommand({
     Resources: [instanceId],

--- a/src/aws.js
+++ b/src/aws.js
@@ -1159,7 +1159,18 @@ async function warmStartInstance(instanceId, { userData, label }) {
   const client = ec2Client();
   await client.send(new ModifyInstanceAttributeCommand({
     InstanceId: instanceId,
-    UserData: { Value: Buffer.from(userData).toString('base64') },
+    // ModifyInstanceAttribute's UserData is a BLOB (BlobAttributeValue.Value:
+    // Uint8Array), NOT the plain string RunInstances takes. The SDK
+    // base64-encodes the blob's bytes for the EC2 query wire, so hand it the
+    // RAW user-data bytes. Pre-encoding to a base64 STRING here double-encodes
+    // it: the wire carries base64(base64(userData)), EC2 decodes that once and
+    // IMDS then serves the base64 TEXT instead of the script. The warm-restart
+    // register step reads that via IMDS, its `sed` finds no GH_REPO_URL='...'
+    // line, and config.sh aborts with "Invalid configuration provided for url"
+    // — every reuse: stop warm start failed registration this way. Cold
+    // launches were unaffected: RunInstances (startEc2Instance) correctly
+    // pre-encodes because its UserData field is a string, not a blob.
+    UserData: { Value: Buffer.from(userData) },
   }));
   await client.send(new CreateTagsCommand({
     Resources: [instanceId],

--- a/tests/warmpool-userdata-encoding.test.js
+++ b/tests/warmpool-userdata-encoding.test.js
@@ -1,0 +1,66 @@
+// Serialization regression for the warm-pool (reuse: stop) user-data rewrite.
+//
+// warmStartInstance rewrites a stopped instance's user-data via
+// ModifyInstanceAttribute before restarting it. That field is a BLOB
+// (BlobAttributeValue.Value: Uint8Array), unlike RunInstances' plain-string
+// UserData. The EC2 query protocol base64-encodes a blob's bytes on the wire,
+// and EC2 base64-decodes them once before storing what IMDS serves. So the
+// value handed to the SDK must be the RAW user-data bytes: a pre-base64'd
+// string double-encodes (wire carries base64(base64(userData))), EC2 decodes
+// only the outer layer, and IMDS ends up serving the base64 TEXT instead of
+// the bootstrap script. The per-boot register step then reads an empty
+// GH_REPO_URL and config.sh aborts with "Invalid configuration provided for
+// url" — the failure this test guards against.
+//
+// Unlike warmpool.test.js this file does NOT mock @aws-sdk/client-ec2: it runs
+// a real EC2Client through a capturing requestHandler so the assertion pins
+// the SDK's actual wire behavior, not a re-implementation of it.
+const { EC2Client, ModifyInstanceAttributeCommand } = require('@aws-sdk/client-ec2');
+
+// Serialize a ModifyInstanceAttribute request and return what EC2 would store
+// as user-data (i.e. IMDS-served bytes) = the wire UserData.Value blob decoded
+// once from base64.
+async function imdsWouldServe(value) {
+  let body = null;
+  const client = new EC2Client({
+    region: 'us-east-1',
+    credentials: { accessKeyId: 'AKIATEST', secretAccessKey: 'secret' },
+    requestHandler: {
+      handle(req) {
+        body = req.body;
+        // Abort before any network I/O; we only need the serialized body.
+        return Promise.reject(new Error('__captured__'));
+      },
+    },
+  });
+  try {
+    await client.send(new ModifyInstanceAttributeCommand({
+      InstanceId: 'i-abc', UserData: { Value: value },
+    }));
+  } catch (err) {
+    if (err.message !== '__captured__') throw err;
+  }
+  const match = /(?:^|&)UserData\.Value=([^&]*)/.exec(body || '');
+  if (!match) throw new Error(`UserData.Value not found in serialized body: ${body}`);
+  const wire = decodeURIComponent(match[1]);
+  return Buffer.from(wire, 'base64').toString('utf8');
+}
+
+describe('ModifyInstanceAttribute user-data blob encoding', () => {
+  const userData = "#!/bin/bash\nGH_REPO_URL='https://github.com/o/r'\nGH_TOKEN='TOK'\n";
+
+  test('raw user-data bytes (the fix) survive the round-trip verbatim', async () => {
+    // This is exactly what warmStartInstance passes: Buffer.from(userData).
+    await expect(imdsWouldServe(Buffer.from(userData))).resolves.toBe(userData);
+  });
+
+  test("a pre-base64'd string (the bug) double-encodes and loses the script", async () => {
+    const served = await imdsWouldServe(Buffer.from(userData).toString('base64'));
+    // IMDS would serve base64 text, not the script — no GH_REPO_URL line, so
+    // the warm-restart register step reads an empty URL.
+    expect(served).not.toBe(userData);
+    expect(served).not.toMatch(/^GH_REPO_URL=/m);
+    // It's the singly-encoded base64 of the script (the double-encode victim).
+    expect(served).toBe(Buffer.from(userData).toString('base64'));
+  });
+});

--- a/tests/warmpool.test.js
+++ b/tests/warmpool.test.js
@@ -87,7 +87,14 @@ describe('warmStartInstance', () => {
     expect(commandsSent()).toEqual(['ModifyInstanceAttribute', 'CreateTags', 'StartInstances']);
     const modify = mockSend.mock.calls[0][0];
     expect(modify.InstanceId).toBe('i-1');
-    expect(Buffer.from(modify.UserData.Value, 'base64').toString('utf8')).toContain('#!/bin/bash');
+    // UserData.Value must be the RAW user-data bytes, not a pre-base64'd
+    // string: it's a blob the SDK base64-encodes on the wire, so a base64
+    // string here double-encodes and IMDS serves base64 text (see
+    // warmStartInstance + the #66 serialization regression test). Assert the
+    // bytes decode straight back to the script — this fails against the old
+    // `.toString('base64')` value (a base64 string, not a Buffer/Uint8Array).
+    expect(Buffer.isBuffer(modify.UserData.Value) || modify.UserData.Value instanceof Uint8Array).toBe(true);
+    expect(Buffer.from(modify.UserData.Value).toString('utf8')).toBe('#!/bin/bash\ntrue');
     const tags = mockSend.mock.calls[1][0].Tags.map((t) => t.Key);
     expect(tags).toContain(aws.LABEL_TAG_KEY);
   });


### PR DESCRIPTION
## Summary

Fixes warm-pool (`reuse: stop`) registration, which failed **100% of the time** on every warm restart with:

```
EC2 runner bootstrap failed during the "configuring" step —
Invalid configuration provided for url. Terminating unattended configuration.
```

### Root cause — double base64 encoding

`warmStartInstance()` rewrites a stopped pool instance's user-data via **`ModifyInstanceAttribute`** before restarting it, so the per-boot register service re-registers with a fresh token/label.

That field is a **blob** (`BlobAttributeValue.Value: Uint8Array`), unlike the plain **string** `UserData` that `RunInstances` takes. The EC2 query protocol base64-encodes a blob's bytes on the wire, and EC2 base64-decodes them **once** before storing what IMDS serves.

The code handed the SDK an *already*-base64'd string:

```js
UserData: { Value: Buffer.from(userData).toString('base64') }  // ❌ double-encodes
```

So the wire carried `base64(base64(userData))`; EC2 decoded only the outer layer and **IMDS served the base64 *text* of the script instead of the script**. The per-boot register step reads user-data back from IMDS and `sed`-greps `GH_REPO_URL='...'` out of it — against a single base64 blob line there is no match, `GH_REPO_URL` is empty, and `config.sh --url ""` aborts with the error above.

Cold launches were unaffected: `RunInstances`' `UserData` is a *string* the caller correctly pre-encodes (`startEc2Instance`).

### Fix

```js
UserData: { Value: Buffer.from(userData) }  // ✅ raw bytes; SDK does the single base64 layer
```

### Verification

Captured the actual serialized `ModifyInstanceAttribute` request body through a real `EC2Client`:

| `UserData.Value` | what IMDS serves (base64-decoded once) |
|---|---|
| `Buffer.from(userData).toString('base64')` (old) | `IyEvYmluL2Jhc2gK…` — base64 text, **no** `GH_REPO_URL` line |
| `Buffer.from(userData)` (new) | `#!/bin/bash\nGH_REPO_URL='…'` — the real script ✅ |

### Tests

- **Strengthened** the `warmStartInstance` unit test: it now asserts the SDK receives the raw script bytes (`Buffer`/`Uint8Array`), not a pre-encoded string. The previous assertion base64-decoded the value, which only passed *because* the value was wrongly pre-encoded — it now fails against the bug.
- **Added** `tests/warmpool-userdata-encoding.test.js`: runs a real `EC2Client` through a capturing request handler and asserts raw bytes round-trip to the script verbatim, while a pre-base64'd string double-encodes and loses it. This pins the SDK wire contract independently of our code.

`npm run lint`, `npm test` (239 passing), and `npm run package` (dist rebuilt) all clean.