### PR TITLE
fix: wait for the stopped state in mode:stop before returning

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -104662,6 +104662,7 @@ const {
   ModifyInstanceAttributeCommand,
   AssociateAddressCommand,
   waitUntilInstanceRunning,
+  waitUntilInstanceStopped,
 } = __nccwpck_require__(5193);
 const fs = __nccwpck_require__(9896);
 const core = __nccwpck_require__(7484);
@@ -105835,11 +105836,32 @@ async function warmStartInstance(instanceId, { userData, label }) {
 }
 
 // Stop (not terminate) an instance so it can be reused from the pool.
+//
+// Blocks until the instance actually reaches the `stopped` state before
+// returning. StopInstances alone only moves it to `stopping`, and a warm-pool
+// lookup that runs during that window (findStoppedPoolInstance filters on
+// instance-state-name=stopped) sees an empty pool and cold-launches a
+// duplicate instance the reaper won't drain until its stopped-max-age passes.
+// Waiting here makes "mode: stop finished" imply "instance is reusable", which
+// is the serialization boundary queued follow-up workflow runs rely on.
 async function stopInstanceById(instanceId) {
   const client = ec2Client();
   await withRetry('stop_instance', () => client.send(new StopInstancesCommand({ InstanceIds: [instanceId] })));
   log.info('stop_instance', { instance_id: instanceId });
-  core.info(`AWS EC2 instance ${instanceId} is stopped (warm pool)`);
+  const start = Date.now();
+  log.info('wait_for_instance_stopped', { instance_id: instanceId });
+  try {
+    await waitUntilInstanceStopped(
+      { client, maxWaitTime: 300 },
+      { InstanceIds: [instanceId] },
+    );
+    log.info('wait_for_instance_stopped', { instance_id: instanceId, elapsed_ms: Date.now() - start });
+    core.info(`AWS EC2 instance ${instanceId} is stopped (warm pool)`);
+  } catch (error) {
+    log.error('wait_for_instance_stopped', { instance_id: instanceId, error: error.name, message: error.message });
+    core.error(`AWS EC2 instance ${instanceId} did not reach the stopped state within the wait window`);
+    throw error;
+  }
 }
 
 // Read the reuse-cycle counter tag for an instance (0 when absent).

--- a/src/aws.js
+++ b/src/aws.js
@@ -12,6 +12,7 @@ const {
   ModifyInstanceAttributeCommand,
   AssociateAddressCommand,
   waitUntilInstanceRunning,
+  waitUntilInstanceStopped,
 } = require('@aws-sdk/client-ec2');
 const fs = require('fs');
 const core = require('@actions/core');
@@ -1185,11 +1186,32 @@ async function warmStartInstance(instanceId, { userData, label }) {
 }
 
 // Stop (not terminate) an instance so it can be reused from the pool.
+//
+// Blocks until the instance actually reaches the `stopped` state before
+// returning. StopInstances alone only moves it to `stopping`, and a warm-pool
+// lookup that runs during that window (findStoppedPoolInstance filters on
+// instance-state-name=stopped) sees an empty pool and cold-launches a
+// duplicate instance the reaper won't drain until its stopped-max-age passes.
+// Waiting here makes "mode: stop finished" imply "instance is reusable", which
+// is the serialization boundary queued follow-up workflow runs rely on.
 async function stopInstanceById(instanceId) {
   const client = ec2Client();
   await withRetry('stop_instance', () => client.send(new StopInstancesCommand({ InstanceIds: [instanceId] })));
   log.info('stop_instance', { instance_id: instanceId });
-  core.info(`AWS EC2 instance ${instanceId} is stopped (warm pool)`);
+  const start = Date.now();
+  log.info('wait_for_instance_stopped', { instance_id: instanceId });
+  try {
+    await waitUntilInstanceStopped(
+      { client, maxWaitTime: 300 },
+      { InstanceIds: [instanceId] },
+    );
+    log.info('wait_for_instance_stopped', { instance_id: instanceId, elapsed_ms: Date.now() - start });
+    core.info(`AWS EC2 instance ${instanceId} is stopped (warm pool)`);
+  } catch (error) {
+    log.error('wait_for_instance_stopped', { instance_id: instanceId, error: error.name, message: error.message });
+    core.error(`AWS EC2 instance ${instanceId} did not reach the stopped state within the wait window`);
+    throw error;
+  }
 }
 
 // Read the reuse-cycle counter tag for an instance (0 when absent).

--- a/tests/warmpool.test.js
+++ b/tests/warmpool.test.js
@@ -18,6 +18,7 @@ jest.mock('@aws-sdk/client-ec2', () => ({
   ModifyInstanceAttributeCommand: jest.fn((p) => ({ __command: 'ModifyInstanceAttribute', ...p })),
   AssociateAddressCommand: jest.fn((p) => ({ __command: 'AssociateAddress', ...p })),
   waitUntilInstanceRunning: jest.fn(),
+  waitUntilInstanceStopped: jest.fn(),
 }));
 jest.mock('../src/retry', () => ({ withRetry: (_step, fn) => fn() }));
 jest.mock('../src/config', () => ({
@@ -101,11 +102,27 @@ describe('warmStartInstance', () => {
 });
 
 describe('stopInstanceById', () => {
-  test('sends StopInstances', async () => {
+  const { waitUntilInstanceStopped } = require('@aws-sdk/client-ec2');
+
+  beforeEach(() => waitUntilInstanceStopped.mockReset());
+
+  test('sends StopInstances, then waits for the stopped state', async () => {
     mockSend.mockResolvedValue({});
+    waitUntilInstanceStopped.mockResolvedValueOnce({ state: 'SUCCESS' });
     await aws.stopInstanceById('i-9');
     expect(commandsSent()).toEqual(['StopInstances']);
     expect(mockSend.mock.calls[0][0].InstanceIds).toEqual(['i-9']);
+    // The waiter is the whole point: returning at `stopping` lets a queued
+    // follow-up run see an empty pool and cold-launch a duplicate instance.
+    expect(waitUntilInstanceStopped).toHaveBeenCalledTimes(1);
+    expect(waitUntilInstanceStopped.mock.calls[0][1]).toEqual({ InstanceIds: ['i-9'] });
+  });
+
+  test('throws when the instance never reaches stopped', async () => {
+    mockSend.mockResolvedValue({});
+    waitUntilInstanceStopped.mockRejectedValueOnce(new Error('TimeoutError'));
+    await expect(aws.stopInstanceById('i-9')).rejects.toThrow('TimeoutError');
+    expect(commandsSent()).toEqual(['StopInstances']);
   });
 });
 


### PR DESCRIPTION
## Problem

`mode: stop` with `reuse: stop` returns as soon as `StopInstances` is accepted — the instance is still in the `stopping` state for the next ~30–60s. Every warm-pool lookup (`findStoppedPoolInstance` and workflow-side pre-attach filters) matches `instance-state-name=stopped` only, so a workflow run queued tightly behind the stopping one sees an **empty pool and cold-launches a duplicate instance**. The duplicate then sits stopped all day (the leak reaper's default `reaper-stopped-max-age` correctly skips same-day instances) and every subsequent run warns `Found 2 stopped warm-pool instances (…); the reaper is not draining them`.

## Evidence (terraform-provider-namecheap CI, 2026-07-10, UTC)

| time | event |
|---|---|
| 08:45:48.70 | run A stop-runner: `{"step":"stop_instance","instance_id":"i-060edd…"}` — `is stopped (warm pool)` printed **0.2 ms** later |
| 08:45:51 | run A stop-runner job completes (instance actually in `stopping`) |
| 08:45:55 | run B's workflow-queue releases (run A finished) |
| 08:46:04 | run B: `{"step":"warm_start","outcome":"pool_empty"}` → cold-launches `i-087854…` |
| 09:26 → 10:08 | every run warns `Found 2 stopped warm-pool instances` |

Same two-instance pattern the previous day (`i-049890…`/`i-03e692…`).

## Fix

Block `stopInstanceById` on `waitUntilInstanceStopped` (`maxWaitTime: 300`, mirroring `waitForInstanceRunning`'s conventions) so "`mode: stop` finished" implies "instance is reusable" — that is the serialization boundary queued follow-up runs rely on. A stop that can't complete within the window now fails the step loudly (previously a silent race).

Consumer-side counterpart (widening the pre-attach filter to `stopped,stopping` + `aws ec2 wait instance-stopped`) ships in the terraform-provider-namecheap workflow; either fix alone closes the race, together they're belt-and-braces.

## Testing

- `stopInstanceById` test asserts the waiter is invoked after `StopInstances` with the right instance id; new negative test asserts a waiter timeout propagates.
- Full suite: 19 suites / 245 tests green; `npm run lint` clean; `dist/` rebuilt via `npm ci && npm run package`.

## Cost note

stop-runner jobs now run ~30–60s longer (hosted-runner minutes) — that's the price of the boundary being truthful; the duplicate t3.medium + EBS parked daily cost more.